### PR TITLE
support for ES 7 (fixes #155)

### DIFF
--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -108,7 +108,12 @@ sudo dpkg \
     -i \
     --force-confnew \
     elasticsearch.deb
-sudo systemctl enable elasticsearch.service
+
+# deal with permissions (https://bit.ly/2ktshmX)
+sudo chown -R \
+    elasticsearch:elasticsearch \
+    /etc/default/elasticsearch
+
 sudo service elasticsearch start
 sleep ${SLEEP_TIL_STARTUP_SECONDS}
 sudo service elasticsearch status

--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -109,7 +109,8 @@ sudo dpkg \
     --force-confnew \
     elasticsearch.deb
 
-# deal with permissions (https://bit.ly/2ktshmX)
+# deal with permissions
+# reference: https://discuss.elastic.co/t/permission-denied-starting-elasticsearch-7-0/179336
 sudo chown -R \
     elasticsearch:elasticsearch \
     /etc/default/elasticsearch

--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -17,104 +17,97 @@ TEST_DATA_DIR=$(pwd)/test_data
 LEGACY_MAPPING_FILE="${TEST_DATA_DIR}/legacy_shakespeare_mapping.json"
 ES5_MAPPING_FILE="${TEST_DATA_DIR}/es5_shakespeare_mapping.json"
 ES6_MAPPING_FILE="${TEST_DATA_DIR}/es6_shakespeare_mapping.json"
-
+ES7_MAPPING_FILE="${TEST_DATA_DIR}/es7_shakespeare_mapping.json"
 
 case "$ES_VERSION" in
     "") ;;
 
     "1.0.0")
-      export ES_VERSION=1.0.0;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES1_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "1.4.4")
-      export ES_VERSION=1.4.4;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES1_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "1.7.2")
-      export ES_VERSION=1.7.2;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES1_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "2.0.2")
-      export ES_VERSION=2.0.2;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES2_ARCHIVE}/$ES_VERSION/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "2.1.2")
-      export ES_VERSION=2.1.2;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES2_ARCHIVE}/$ES_VERSION/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "2.2.2")
-      export ES_VERSION=2.2.2;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES2_ARCHIVE}/$ES_VERSION/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "2.3.5")
-      export ES_VERSION=2.3.5;
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES2_ARCHIVE}/$ES_VERSION/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "5.0.2")
-      export ES_VERSION=5.0.2;
       export MAPPING_FILE=${ES5_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "5.3.3")
-      export ES_VERSION=5.3.3;
       export MAPPING_FILE=${ES5_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
-    
+
     "5.4.3")
-      export ES_VERSION=5.4.3;
       export MAPPING_FILE=${ES5_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
     "5.6.9")
-      export ES_VERSION=5.6.9;
       export MAPPING_FILE=${ES5_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
-    
+
     "6.0.1")
-      export ES_VERSION=6.0.1;
       export MAPPING_FILE=${ES6_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
-    
+
     "6.1.4")
       export ES_VERSION=6.1.4;
       export MAPPING_FILE=${ES6_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
-      
+
     "6.2.4")
-      export ES_VERSION=6.2.4;
       export MAPPING_FILE=${ES6_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
+      ;;
+
+    "7.3.1")
+      export MAPPING_FILE=${ES7_MAPPING_FILE};
+      export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
       ;;
    esac
 
 # pull the binary
-curl -O ${ES_BINARY_URL}
+curl ${ES_BINARY_URL} \
+    --output elasticsearch.deb
 
 # start the service and wait a bit
 sudo dpkg \
     -i \
     --force-confnew \
-    elasticsearch-$ES_VERSION.deb
+    elasticsearch.deb
 sudo service elasticsearch start
 sleep ${SLEEP_TIL_STARTUP_SECONDS}
 sudo service elasticsearch status

--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -19,6 +19,9 @@ ES5_MAPPING_FILE="${TEST_DATA_DIR}/es5_shakespeare_mapping.json"
 ES6_MAPPING_FILE="${TEST_DATA_DIR}/es6_shakespeare_mapping.json"
 ES7_MAPPING_FILE="${TEST_DATA_DIR}/es7_shakespeare_mapping.json"
 
+SAMPLE_DATA_FILE=${TEST_DATA_DIR}/sample.json
+ES7_SAMPLE_DATA_FILE=${TEST_DATA_DIR}/sample_es7.json
+
 case "$ES_VERSION" in
     "") ;;
 
@@ -96,6 +99,8 @@ case "$ES_VERSION" in
     "7.3.1")
       export MAPPING_FILE=${ES7_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
+      # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data
+      export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
       ;;
    esac
 
@@ -135,7 +140,7 @@ curl -X PUT \
     -H 'Content-Type:application/json' \
     -d @shakespeare_mapping.json
 
-mv test_data/sample.json sample.json
+mv ${SAMPLE_DATA_FILE} sample.json
 
 curl -X POST \
     "${ES_HOST}/shakespeare/_bulk" \

--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -108,6 +108,7 @@ sudo dpkg \
     -i \
     --force-confnew \
     elasticsearch.deb
+sudo systemctl enable elasticsearch.service
 sudo service elasticsearch start
 sleep ${SLEEP_TIL_STARTUP_SECONDS}
 sudo service elasticsearch status

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -11,7 +11,7 @@ export JAVA_APT_PKG="oracle-java8-set-default"
 # install these testing packages we need
 if [[ "$TASK" == "rpkg" ]];
 then
-  Rscript -e "install.packages(c('devtools', 'knitr', 'testthat', 'rmarkdown'), repos = 'http://cran.rstudio.com')"
+  Rscript -e "install.packages(c('data.table', 'devtools', 'futile.logger', 'knitr', 'testthat', 'rmarkdown', 'uuid'), repos = 'http://cran.rstudio.com')"
   cp test_data/* r-pkg/inst/testdata/
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,167 +30,179 @@ script:
 # - ES_VERSION=6.0.1
 # - ES_VERSION=6.1.4
 # - ES_VERSION=6.2.4
+# - ES_VERSION=7.3.1
 matrix:
   include:
     ############
     # R builds #
     ############
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=1.0.0
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=1.4.4
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=1.7.2
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=2.0.2
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=2.1.2
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=2.2.2
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=2.3.5
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=5.0.2
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=5.3.3
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=5.4.3
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=5.6.9
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=6.0.1
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=6.1.4
-        - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=1.0.0
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=1.4.4
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=1.7.2
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=2.0.2
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=2.1.2
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=2.2.2
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=2.3.5
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=5.0.2
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=5.3.3
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=5.4.3
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=5.6.9
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=6.0.1
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=6.1.4
+    #     - TASK=rpkg
     - language: r
       warnings_are_errors: true
       cache: packages
       env:
         - ES_VERSION=6.2.4
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.3.1
         - TASK=rpkg
       after_success:
         - .ci/report_to_covr.sh
-    #################
-    # Python builds #
-    #################
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=1.0.0
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=1.4.4
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=1.7.2
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=2.0.2
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=2.1.2
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=2.2.2
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=2.3.5
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=5.0.2
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=5.3.3
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=5.4.3
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=5.6.9
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=6.0.1
-        - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=6.1.4
-        - TASK=pypkg
+    # #################
+    # # Python builds #
+    # #################
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=1.0.0
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=1.4.4
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=1.7.2
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=2.0.2
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=2.1.2
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=2.2.2
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=2.3.5
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=5.0.2
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=5.3.3
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=5.4.3
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=5.6.9
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=6.0.1
+    #     - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=6.1.4
+    #     - TASK=pypkg
     - language: python
       python: 3.5
       env:
         - ES_VERSION=6.2.4
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=7.3.1
         - TASK=pypkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - .ci/install.sh
 
 before_script:
-  - .ci/seed_es_on_travis.sh
+  - sudo .ci/seed_es_on_travis.sh
 
 script:
   - .ci/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,20 +114,20 @@ matrix:
     #   env:
     #     - ES_VERSION=6.1.4
     #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=6.2.4
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=7.3.1
-    #     - TASK=rpkg
-    #   after_success:
-    #     - .ci/report_to_covr.sh
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=6.2.4
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.3.1
+        - TASK=rpkg
+      after_success:
+        - .ci/report_to_covr.sh
     # #################
     # # Python builds #
     # #################
@@ -196,11 +196,11 @@ matrix:
     #   env:
     #     - ES_VERSION=6.1.4
     #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=6.2.4
-    #     - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=6.2.4
+        - TASK=pypkg
     - language: python
       python: 3.5
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,20 +114,20 @@ matrix:
     #   env:
     #     - ES_VERSION=6.1.4
     #     - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=6.2.4
-        - TASK=rpkg
-    - language: r
-      warnings_are_errors: true
-      cache: packages
-      env:
-        - ES_VERSION=7.3.1
-        - TASK=rpkg
-      after_success:
-        - .ci/report_to_covr.sh
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=6.2.4
+    #     - TASK=rpkg
+    # - language: r
+    #   warnings_are_errors: true
+    #   cache: packages
+    #   env:
+    #     - ES_VERSION=7.3.1
+    #     - TASK=rpkg
+    #   after_success:
+    #     - .ci/report_to_covr.sh
     # #################
     # # Python builds #
     # #################
@@ -196,11 +196,11 @@ matrix:
     #   env:
     #     - ES_VERSION=6.1.4
     #     - TASK=pypkg
-    - language: python
-      python: 3.5
-      env:
-        - ES_VERSION=6.2.4
-        - TASK=pypkg
+    # - language: python
+    #   python: 3.5
+    #   env:
+    #     - ES_VERSION=6.2.4
+    #     - TASK=pypkg
     - language: python
       python: 3.5
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - .ci/install.sh
 
 before_script:
-  - sudo .ci/seed_es_on_travis.sh
+  - .ci/seed_es_on_travis.sh
 
 script:
   - .ci/test.sh
@@ -36,84 +36,84 @@ matrix:
     ############
     # R builds #
     ############
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=1.0.0
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=1.4.4
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=1.7.2
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=2.0.2
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=2.1.2
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=2.2.2
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=2.3.5
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=5.0.2
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=5.3.3
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=5.4.3
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=5.6.9
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=6.0.1
-    #     - TASK=rpkg
-    # - language: r
-    #   warnings_are_errors: true
-    #   cache: packages
-    #   env:
-    #     - ES_VERSION=6.1.4
-    #     - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=1.0.0
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=1.4.4
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=1.7.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=2.0.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=2.1.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=2.2.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=2.3.5
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=5.0.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=5.3.3
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=5.4.3
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=5.6.9
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=6.0.1
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=6.1.4
+        - TASK=rpkg
     - language: r
       warnings_are_errors: true
       cache: packages
@@ -128,74 +128,74 @@ matrix:
         - TASK=rpkg
       after_success:
         - .ci/report_to_covr.sh
-    # #################
-    # # Python builds #
-    # #################
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=1.0.0
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=1.4.4
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=1.7.2
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=2.0.2
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=2.1.2
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=2.2.2
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=2.3.5
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=5.0.2
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=5.3.3
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=5.4.3
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=5.6.9
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=6.0.1
-    #     - TASK=pypkg
-    # - language: python
-    #   python: 3.5
-    #   env:
-    #     - ES_VERSION=6.1.4
-    #     - TASK=pypkg
+    #################
+    # Python builds #
+    #################
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=1.0.0
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=1.4.4
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=1.7.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=2.0.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=2.1.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=2.2.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=2.3.5
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=5.0.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=5.3.3
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=5.4.3
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=5.6.9
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=6.0.1
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=6.1.4
+        - TASK=pypkg
     - language: python
       python: 3.5
       env:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-### Full support for ES7.x
+### Added support for ES7.x
 - [#161](https://github.com/uptake/uptasticsearch/pull/161) Added support for ES7.x. The biggest changes between that major version and 6.x were the removal of `_all` as a way to reference all indices, changing the response format of `hits.total` into an object like `{"hits": {"total": 50}}`, and restricting all indices to have a single type of document. More details can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html.
 
 # uptasticsearch 0.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# uptasticsearch development version
+
+## Features
+
+### Full support for ES7.x
+- [#161](https://github.com/uptake/uptasticsearch/pull/161) Added support for ES7.x. The biggest changes between that major version and 6.x were the removal of `_all` as a way to reference all indices, changing the response format of `hits.total` into an object like `{"hits": {"total": 50}}`, and restricting all indices to have a single type of document. More details can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html.
+
 # uptasticsearch 0.3.1
 
 ## Bugfixes

--- a/py-pkg/setup.py
+++ b/py-pkg/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 import subprocess
 import datetime
 
-CURRENT_VERSION = "0.1.0"
+CURRENT_VERSION = "0.2.0"
 
 #########################
 

--- a/py-pkg/tests/test_clients.py
+++ b/py-pkg/tests/test_clients.py
@@ -16,14 +16,18 @@ from uptasticsearch.fetch_all import es_search
 
 class TestEsSearch(object):
     """
-    es_search should work an return a pandas DataFrame
+    es_search should work and return a pandas DataFrame
     """
     host = "http://127.0.0.1:9200"
+
     def test_rectangle(self):
-        assert isinstance(es_search(self.host,
-                                    "shakespeare",
-                                    query_body=json.dumps({}),
-                                    size=10000,
-                                    max_hits=10,
-                                    scroll="1m"),
-                          pd.DataFrame)
+        result = es_search(
+            self.host,
+            "shakespeare",
+            query_body=json.dumps({}),
+            size=10000,
+            max_hits=10,
+            scroll="1m"
+        )
+        print(result)
+        assert isinstance(result, pd.DataFrame)

--- a/py-pkg/tests/test_clients.py
+++ b/py-pkg/tests/test_clients.py
@@ -8,6 +8,7 @@ from uptasticsearch.clients import Uptasticsearch1
 from uptasticsearch.clients import Uptasticsearch2
 from uptasticsearch.clients import Uptasticsearch5
 from uptasticsearch.clients import Uptasticsearch6
+from uptasticsearch.clients import Uptasticsearch7
 from uptasticsearch.clients import uptasticsearch_factory
 
 from uptasticsearch.fetch_all import es_search

--- a/py-pkg/uptasticsearch/clients.py
+++ b/py-pkg/uptasticsearch/clients.py
@@ -33,6 +33,14 @@ class Uptasticsearch(object):
         self.url = _format_es_url(url)
         self.client = http_client
 
+    def _get_total_hits(self, response_json):
+        """
+        Given a dictionary representing the content of a
+        respose to a  ``POST /_search`` request, return the total
+        number of docs matching the query
+        """
+        return response_json['hits']['total']
+
     def search(self, body, index="", doc_type="", scroll_context_timer="1m", page_size=10000,  max_hits=None):
         """Execute a Search Query on the Elasticsearch Cluster
 
@@ -60,7 +68,7 @@ class Uptasticsearch(object):
                                     headers={'Content-Type': 'application/json'})
 
         page = response.json()
-        total_hits = page['hits']['total']
+        total_hits = self._get_total_hits(page)
         total_hits = min(total_hits, max_hits) if max_hits is not None else total_hits
 
         results = [d['_source'] for d in page['hits']['hits']]
@@ -118,13 +126,26 @@ class Uptasticsearch6(Uptasticsearch):
                                                  "scroll_id": scroll_id}),
                                 headers={'Content-Type': 'application/json'})
 
+class Uptasticsearch7(Uptasticsearch6):
+
+    def _get_total_hits(self, response_json):
+        """
+        Given a dictionary representing the content of a
+        respose to a  ``POST /_search`` request, return the total
+        number of docs matching the query
+        """
+        return response_json['hits']['total']['value']
+
 
 def uptasticsearch_factory(url, retries=5, backoff_factor=0.1):
     http_client = HttpClient(retries=retries, backoff_factor=backoff_factor)
     es_url = _format_es_url(url)
     cluster_version = http_client.get(es_url).json()['version']['number'].split('.')[0]
 
-    return {"1": Uptasticsearch1,
-            "2": Uptasticsearch2,
-            "5": Uptasticsearch5,
-            "6": Uptasticsearch6}[cluster_version](es_url, http_client)
+    return {
+        "1": Uptasticsearch1,
+        "2": Uptasticsearch2,
+        "5": Uptasticsearch5,
+        "6": Uptasticsearch6,
+        "7": Uptasticsearch7
+    }[cluster_version](es_url, http_client)

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: uptasticsearch
 Type: Package
 Title: Get Data Frame Representations of 'Elasticsearch' Results
-Version: 0.3.1
+Version: 0.4.1
 Authors@R: c(
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut", "cre")),
     person("Nick", "Paras", email = "nick.paras@uptake.com", role = c("aut")),

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -296,7 +296,13 @@ es_search <- function(es_host
 
     # Parse to JSON to get total number of documents matching the query
     firstResult <- jsonlite::fromJSON(firstResultJSON, simplifyVector = FALSE)
-    hits_to_pull <- min(firstResult[["hits"]][["total"]], max_hits)
+
+    major_version <- .get_es_version(es_host)
+    if (as.integer(major_version) > 6){
+      hits_to_pull <- min(firstResult[["hits"]][["total"]][["value"]], max_hits)
+    } else {
+      hits_to_pull <- min(firstResult[["hits"]][["total"]], max_hits)
+    }
 
     # If we got everything possible, just return here
     hits_pulled <- length(firstResult[["hits"]][["hits"]])

--- a/r-pkg/tests/testthat/test-get_fields.R
+++ b/r-pkg/tests/testthat/test-get_fields.R
@@ -3,7 +3,7 @@ context("get_fields")
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
 if (!identical(loggerOptions, list())){
-    origLogThreshold <- loggerOptions[[1]][['threshold']]    
+    origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO
 }
@@ -23,7 +23,7 @@ futile.logger::flog.threshold(0)
                                regexp = "get_fields must be passed a valid es_indices")
               }
     )
-    
+
     # works as expected when mocked
     test_that('get_fields works as expected when mocked',
               {
@@ -35,6 +35,7 @@ futile.logger::flog.threshold(0)
                       `httr::GET` = function(...) {return(NULL)},
                       `httr::content` = function(...) {return(jsonlite::fromJSON(txt = test_json))},
                       `uptasticsearch::.get_aliases` = function(...) {return(aliasDT)},
+                      `uptasticsearch::.get_es_version` = function(...) {return("6")},
                       {
                           outDT <- get_fields(es_host = 'http://db.mycompany.com:9200'
                                               , es_indices = c('company', 'hotel'))
@@ -52,10 +53,10 @@ futile.logger::flog.threshold(0)
                   )
               }
     )
-    
-    
+
+
 #--- .flatten_mapping
-    
+
     # Works if one index is passed
     test_that(".flatten_mapping should work if the mapping for one index is provided",
               {
@@ -71,7 +72,7 @@ futile.logger::flog.threshold(0)
                   expect_identical(mappingDT, expected)
               }
     )
-    
+
     # works if multiple indices are passed
     test_that(".flatten_mapping should work if the mapping for multiple indices are provided",
               {
@@ -91,7 +92,7 @@ futile.logger::flog.threshold(0)
     )
 
 #--- .process_alias
-    
+
     # works if one alias is passed
     test_that(".process_new_alias works if one alias is included",
               {
@@ -101,7 +102,7 @@ futile.logger::flog.threshold(0)
                   expect_identical(aliasDT, expected)
               }
     )
-    
+
     # works if multiple aliases are passed
     test_that(".process_new_alias works if one alias is included",
               {

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -129,7 +129,14 @@ futile.logger::flog.threshold(0)
         )
 
         expect_true(data.table::is.data.table(outDT))
-        expect_true(nrow(outDT) == 3)
+        num_expected_levels <- 3
+        major_version <- .major_version(
+            .get_es_version("http://127.0.0.1:9200")
+        )
+        if (as.integer(major_version) >= 7){
+            num_expected_levels <- 4
+        }
+        expect_true(nrow(outDT) == num_expected_levels)
         expect_named(
             outDT
             , c("thing", "doc_count")

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -129,12 +129,12 @@ futile.logger::flog.threshold(0)
         )
 
         expect_true(data.table::is.data.table(outDT))
-        num_expected_levels <- 3
+        num_expected_levels <- 4
         major_version <- .major_version(
             .get_es_version("http://127.0.0.1:9200")
         )
         if (as.integer(major_version) >= 7){
-            num_expected_levels <- 4
+            num_expected_levels <- 3
         }
         expect_true(nrow(outDT) == num_expected_levels)
         expect_named(

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -10,7 +10,7 @@ context("Elasticsearch integration tests")
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
 if (!identical(loggerOptions, list())){
-    origLogThreshold <- loggerOptions[[1]][['threshold']]    
+    origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO
 }
@@ -21,7 +21,7 @@ futile.logger::flog.threshold(0)
     # search request
     test_that("es_search works as expected for a simple search request", {
         testthat::skip_on_cran()
-        
+
         outDT <- es_search(
             es_host = "http://127.0.0.1:9200"
             , es_index = "shakespeare"
@@ -31,10 +31,10 @@ futile.logger::flog.threshold(0)
 
        expect_true(data.table::is.data.table(outDT))
     })
-    
+
     test_that("es_search works when you have to scroll", {
         testthat::skip_on_cran()
-        
+
         outDT <- es_search(
             es_host = "http://127.0.0.1:9200"
             , es_index = "shakespeare"
@@ -44,10 +44,10 @@ futile.logger::flog.threshold(0)
         expect_true(data.table::is.data.table(outDT))
         expect_true(nrow(outDT) == 30)
     })
-    
+
     test_that("es_search works in single-threaded mode", {
         testthat::skip_on_cran()
-        
+
         outDT <- es_search(
             es_host = "http://127.0.0.1:9200"
             , es_index = "shakespeare"
@@ -58,10 +58,10 @@ futile.logger::flog.threshold(0)
         expect_true(data.table::is.data.table(outDT))
         expect_true(nrow(outDT) == 30)
     })
-    
+
     test_that("es_search rejects scrolls longer than 1 hour", {
         testthat::skip_on_cran()
-        
+
         expect_error({
             outDT <- es_search(
                 es_host = "http://127.0.0.1:9200"
@@ -71,12 +71,12 @@ futile.logger::flog.threshold(0)
                 , scroll = "2h"
             )
         }, regexp = "By default, this function does not permit scroll requests which keep the scroll")
-        
+
     })
-    
+
     test_that("es_search warns and readjusts size if max_hits less than 10000", {
         testthat::skip_on_cran()
-        
+
         expect_warning({
             outDT <- es_search(
                 es_host = "http://127.0.0.1:9200"
@@ -85,12 +85,12 @@ futile.logger::flog.threshold(0)
             )
         }, regexp = "You requested a maximum of 9999 hits and a page size of 10000")
         expect_true(data.table::is.data.table(outDT))
-        
+
     })
-    
+
     test_that("es_search warns when max hits is not a clean multiple of size", {
         testthat::skip_on_cran()
-        
+
         expect_warning({
             outDT <- es_search(
                 es_host = "http://127.0.0.1:9200"
@@ -101,10 +101,10 @@ futile.logger::flog.threshold(0)
         }, regexp = "When max_hits is not an exact multiple of size, it is possible to get a few more than max_hits results back")
         expect_true(data.table::is.data.table(outDT))
     })
-    
+
     test_that("es_search works as expected for search requests that return nothing", {
         testthat::skip_on_cran()
-        
+
         # NOTE: Creating an intentionally empty index is the safest way to test
         #       this functionality. Any other test would involve writing a query
         #       and I want to avoid exposing our tests to changes in the query DSL
@@ -116,20 +116,20 @@ futile.logger::flog.threshold(0)
         }, regexp = "Query is syntactically valid but 0 documents were matched")
         expect_null(outDT)
     })
-    
+
     # aggregation request
     test_that("es_search works as expected for a simple aggregation request", {
         testthat::skip_on_cran()
-        
+
         outDT <- es_search(
             es_host = "http://127.0.0.1:9200"
             , es_index = "shakespeare"
             , max_hits = 100
             , query = '{"aggs": {"thing": {"terms": {"field": "speaker", "size": 12}}}}'
         )
-        
+
         expect_true(data.table::is.data.table(outDT))
-        expect_true(nrow(outDT) == 4)
+        expect_true(nrow(outDT) == 3)
         expect_named(
             outDT
             , c("thing", "doc_count")
@@ -140,17 +140,17 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(outDT[, thing]))
         expect_true(all(outDT[, doc_count > 0]))
     })
-    
+
     test_that("es_search respects the names you assign to aggregation results", {
         testthat::skip_on_cran()
-        
+
         outDT <- es_search(
             es_host = "http://127.0.0.1:9200"
             , es_index = "shakespeare"
             , max_hits = 100
             , query = '{"aggs": {"name_i_picked": {"terms": {"field": "speaker", "size": 12}}}}'
         )
-        
+
         # main test
         expect_named(
             outDT
@@ -158,14 +158,14 @@ futile.logger::flog.threshold(0)
             , ignore.case = FALSE
             , ignore.order = TRUE
         )
-        
+
         # ther stuff we might as well test
         expect_true(data.table::is.data.table(outDT))
         expect_true(is.numeric(outDT[, doc_count]))
         expect_true(is.character(outDT[, name_i_picked]))
         expect_true(all(outDT[, doc_count > 0]))
     })
-    
+
     # We have tests on static empty results, but this test will catch
     # changes across versions in the way ES actually responds to aggs results that
     # return nothing
@@ -177,29 +177,29 @@ futile.logger::flog.threshold(0)
             , es_index = "shakespeare"
             , max_hits = 100
             , query = '{"aggs": {"blegh": {"terms": {"field": "nonsense_field"}}}}'
-        ) 
+        )
         expect_null(outDT)
     })
 
 #--- .get_es_version
-    
+
     test_that(".get_es_version works", {
         testthat::skip_on_cran()
-        
+
         ver <- uptasticsearch:::.get_es_version(es_host = "http://127.0.0.1:9200")
-        
+
         # is a string
         expect_true(assertthat::is.string(ver), info = paste0("returned version: ", ver))
-        
+
         # Decided to check that it's coercible to an integer instead of
         # hard-coding known ES versions so this test won't require
         # attention or break builds if/when ES7 or whatever the next major verison
         # is comes out
         expect_true(!is.na(as.integer(ver)), info = paste0("returned version: ", ver))
     })
-    
+
 #--- get_fields and .get_aliases
-    
+
     # set up helper function for manipulating aliases. Valid actions below are
     # "add" and "remove"
     .alias_action <- function(action, alias_name){
@@ -215,19 +215,19 @@ futile.logger::flog.threshold(0)
         httr::stop_for_status(res)
         return(invisible(NULL))
     }
-    
+
     test_that(".get_aliases returns NULL when no aliases have been created in the cluster", {
         testthat::skip_on_cran()
-        
+
         result <- .get_aliases(
             es_host = "http://127.0.0.1:9200"
         )
         expect_null(result)
     })
-    
+
     test_that("get_fields works on an actual running ES cluster with no aliases", {
         testthat::skip_on_cran()
-        
+
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"
             , es_indices = "_all"
@@ -245,16 +245,16 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$type))
         expect_true(is.character(fieldDT$field))
         expect_true(is.character(fieldDT$data_type))
-        expect_true(sum(is.na(fieldDT)) == 0)
+        expect_true(sum(is.na(fieldDT[, .(index, field, data_type)])) == 0)
     })
-    
+
     test_that(".get_aliases and get_fields work as expected when exactly one alias exists for one index in the cluster", {
-        
+
         testthat::skip_on_cran()
-        
+
         # create an alias
         .alias_action("add", "the_test_alias")
-        
+
         # get_aliases should work
         resultDT <- .get_aliases("http://127.0.0.1:9200")
         expect_true(data.table::is.data.table(resultDT))
@@ -267,13 +267,13 @@ futile.logger::flog.threshold(0)
         )
         expect_identical(resultDT[, index], "shakespeare")
         expect_identical(resultDT[, alias], "the_test_alias")
-        
+
         # get_fields should work
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"
             , es_indices = "_all"
         )
-        
+
         expect_true(data.table::is.data.table(fieldDT))
         expect_true(nrow(fieldDT) > 0)
         expect_named(
@@ -286,32 +286,32 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$type))
         expect_true(is.character(fieldDT$field))
         expect_true(is.character(fieldDT$data_type))
-        expect_true(sum(is.na(fieldDT)) == 0)
-        
+        expect_true(sum(is.na(fieldDT[, .(index, field, data_type)])) == 0)
+
         # get_fields should replace index names with their aliases
         expect_true(fieldDT[, sum(index == "the_test_alias")] > 0)
         expect_true(
             fieldDT[, sum(index == "shakespeare")] == 0
             , info = "get_fields didn't replace index names with their aliases"
         )
-        
+
         # delete the alias we created (to keep tests self-contained)
         .alias_action("remove", "the_test_alias")
-        
+
         # confirm that it's gone
         resultDT <- .get_aliases("http://127.0.0.1:9200")
         expect_null(resultDT)
     })
-    
+
     test_that(".get_aliases and get_fields work as expected when more than one alias exists for one index in the cluster", {
-        
+
         testthat::skip_on_cran()
-        
+
         # create an alias
         .alias_action('add', 'the_test_alias')
         .alias_action('add', 'the_best_alias')
         .alias_action('add', 'the_nest_alias')
-    
+
         # get_aliases should work
         resultDT <- .get_aliases("http://127.0.0.1:9200")
         expect_true(data.table::is.data.table(resultDT))
@@ -324,13 +324,16 @@ futile.logger::flog.threshold(0)
         )
         expect_identical(resultDT[, index], rep("shakespeare", 3))
         expect_true(resultDT[, all(c("the_best_alias", "the_nest_alias", "the_test_alias") %in% alias)])
-        
+
         # get_fields should work for "_all" indices
+        # NOTE: this was deprecated in Elasticsearch 6 and removed in
+        #       ES7, but we use it here so that old uptasticsearch code
+        #       continues to work
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"
             , es_indices = "_all"
         )
-        
+
         expect_true(data.table::is.data.table(fieldDT))
         expect_true(nrow(fieldDT) > 0)
         expect_named(
@@ -343,15 +346,15 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$type))
         expect_true(is.character(fieldDT$field))
         expect_true(is.character(fieldDT$data_type))
-        expect_true(sum(is.na(fieldDT)) == 0)
-        
+        expect_true(sum(is.na(fieldDT[, .(index, field, data_type)])) == 0)
+
         # get_fields should replace index names with their aliases
         expect_true(fieldDT[, all(c("the_best_alias", "the_nest_alias", "the_test_alias") %in% index)])
         expect_true(
             fieldDT[, sum(index == "shakespeare")] == 0
             , info = "get_fields didn't replace index names with their aliases"
         )
-        
+
         # since we aliased the same index three times, the subsections should all be identical
         expect_true(identical(
             fieldDT[index == 'the_best_alias', .(type, field, data_type)]
@@ -361,13 +364,13 @@ futile.logger::flog.threshold(0)
             fieldDT[index == 'the_best_alias', .(type, field, data_type)]
             , fieldDT[index == 'the_test_alias', .(type, field, data_type)]
         ))
-        
+
         # get_fields should work targeting a specific index with aliases
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"
             , es_indices = "shakespeare"
         )
-        
+
         expect_true(data.table::is.data.table(fieldDT))
         expect_true(nrow(fieldDT) > 0)
         expect_named(
@@ -380,15 +383,15 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$type))
         expect_true(is.character(fieldDT$field))
         expect_true(is.character(fieldDT$data_type))
-        expect_true(sum(is.na(fieldDT)) == 0)
-        
+        expect_true(sum(is.na(fieldDT[, .(index, field, data_type)])) == 0)
+
         # get_fields should replace index names with their aliases
         expect_true(fieldDT[, all(c("the_best_alias", "the_nest_alias", "the_test_alias") %in% index)])
         expect_true(
             fieldDT[, sum(index == "shakespeare")] == 0
             , info = "get_fields didn't replace index names with their aliases"
         )
-        
+
         # since we aliased the same index three times, the subsections should all be identical
         expect_true(identical(
             fieldDT[index == 'the_best_alias', .(type, field, data_type)]
@@ -398,21 +401,21 @@ futile.logger::flog.threshold(0)
             fieldDT[index == 'the_best_alias', .(type, field, data_type)]
             , fieldDT[index == 'the_test_alias', .(type, field, data_type)]
         ))
-        
+
         # delete the aliases we created (to keep tests self-contained)
         .alias_action('remove', 'the_test_alias')
         .alias_action('remove', 'the_best_alias')
         .alias_action('remove', 'the_nest_alias')
-        
+
         # confirm that they're gone
         resultDT <- .get_aliases("http://127.0.0.1:9200")
         expect_null(resultDT)
     })
-    
+
     test_that("get_fields works when you target a single index with no aliases", {
-        
+
         testthat::skip_on_cran()
-        
+
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"
             , es_indices = "empty_index"
@@ -429,17 +432,17 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$type))
         expect_true(is.character(fieldDT$field))
         expect_true(is.character(fieldDT$data_type))
-        expect_true(sum(is.na(fieldDT)) == 0)
-        
+        expect_true(sum(is.na(fieldDT[, .(index, field, data_type)])) == 0)
+
         # should only give us back records on the one index we requested
         expect_true(fieldDT[, all(index == "empty_index")])
     })
-    
-    
+
+
     test_that("get_fields works when you pass a vector of index names", {
-        
+
         testthat::skip_on_cran()
-        
+
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"
             , es_indices = c("empty_index", "shakespeare")
@@ -456,8 +459,8 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$type))
         expect_true(is.character(fieldDT$field))
         expect_true(is.character(fieldDT$data_type))
-        expect_true(sum(is.na(fieldDT)) == 0)
-        
+        expect_true(sum(is.na(fieldDT[, .(index, field, data_type)])) == 0)
+
         # should only give us back records on indexes we requested
         expect_true(fieldDT[, any(index == "empty_index")])
         expect_true(fieldDT[, length(unique(index))] >= 2)

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -84,6 +84,13 @@ case "${MAJOR_VERSION}" in
           docker.elastic.co/elasticsearch/elasticsearch:6.2.4
      MAPPING_FILE=$(pwd)/test_data/es6_shakespeare_mapping.json
     ;;
+7.3) docker run -d -p 9200:9200 \
+          -e "discovery.type=single-node" \
+          -e "xpack.security.enabled=false" \
+          docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+     MAPPING_FILE=$(pwd)/test_data/es7_shakespeare_mapping.json
+     SAMPLE_DATA_FILE=$(pwd)/test_data/sample_es7.json
+    ;;
 *) echo "Did not recognize version ${MAJOR_VERSION}. Not starting Elasticsearch"
    exit 1
    ;;

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -87,7 +87,7 @@ case "${MAJOR_VERSION}" in
 7.3) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+          docker.elastic.co/elasticsearch/elasticsearch:7.3.1
      MAPPING_FILE=$(pwd)/test_data/es7_shakespeare_mapping.json
      SAMPLE_DATA_FILE=$(pwd)/test_data/sample_es7.json
     ;;

--- a/test_data/es7_shakespeare_mapping.json
+++ b/test_data/es7_shakespeare_mapping.json
@@ -1,0 +1,24 @@
+{
+  "mappings": {
+    "properties": {
+      "speaker": {
+        "type": "keyword"
+      },
+      "play_name": {
+        "type": "keyword"
+      },
+      "line_id": {
+        "type": "integer"
+      },
+      "line_number": {
+        "type": "keyword"
+      },
+      "speech_number": {
+        "type": "keyword"
+      },
+      "text_entry": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/test_data/sample_es7.json
+++ b/test_data/sample_es7.json
@@ -1,0 +1,96 @@
+{"index":{"_index":"shakespeare","_id":2}}
+{"line_id":3,"play_name":"Henry IV","speech_number":"","line_number":"","speaker":"","text_entry":"Enter KING HENRY, LORD JOHN OF LANCASTER, the EARL of WESTMORELAND, SIR WALTER BLUNT, and others"}
+{"index":{"_index":"shakespeare","_id":3}}
+{"line_id":4,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.1","speaker":"KING HENRY IV","text_entry":"So shaken as we are, so wan with care,"}
+{"index":{"_index":"shakespeare","_id":4}}
+{"line_id":5,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.2","speaker":"KING HENRY IV","text_entry":"Find we a time for frighted peace to pant,"}
+{"index":{"_index":"shakespeare","_id":5}}
+{"line_id":6,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.3","speaker":"KING HENRY IV","text_entry":"And breathe short-winded accents of new broils"}
+{"index":{"_index":"shakespeare","_id":6}}
+{"line_id":7,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.4","speaker":"KING HENRY IV","text_entry":"To be commenced in strands afar remote."}
+{"index":{"_index":"shakespeare","_id":7}}
+{"line_id":8,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.5","speaker":"KING HENRY IV","text_entry":"No more the thirsty entrance of this soil"}
+{"index":{"_index":"shakespeare","_id":8}}
+{"line_id":9,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.6","speaker":"KING HENRY IV","text_entry":"Shall daub her lips with her own childrens blood;"}
+{"index":{"_index":"shakespeare","_id":9}}
+{"line_id":10,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.7","speaker":"KING HENRY IV","text_entry":"Nor more shall trenching war channel her fields,"}
+{"index":{"_index":"shakespeare","_id":10}}
+{"line_id":11,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.8","speaker":"KING HENRY IV","text_entry":"Nor bruise her flowerets with the armed hoofs"}
+{"index":{"_index":"shakespeare","_id":11}}
+{"line_id":12,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.9","speaker":"KING HENRY IV","text_entry":"Of hostile paces: those opposed eyes,"}
+{"index":{"_index":"shakespeare","_id":12}}
+{"line_id":13,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.10","speaker":"KING HENRY IV","text_entry":"Which, like the meteors of a troubled heaven,"}
+{"index":{"_index":"shakespeare","_id":13}}
+{"line_id":14,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.11","speaker":"KING HENRY IV","text_entry":"All of one nature, of one substance bred,"}
+{"index":{"_index":"shakespeare","_id":14}}
+{"line_id":15,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.12","speaker":"KING HENRY IV","text_entry":"Did lately meet in the intestine shock"}
+{"index":{"_index":"shakespeare","_id":15}}
+{"line_id":16,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.13","speaker":"KING HENRY IV","text_entry":"And furious close of civil butchery"}
+{"index":{"_index":"shakespeare","_id":16}}
+{"line_id":17,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.14","speaker":"KING HENRY IV","text_entry":"Shall now, in mutual well-beseeming ranks,"}
+{"index":{"_index":"shakespeare","_id":17}}
+{"line_id":18,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.15","speaker":"KING HENRY IV","text_entry":"March all one way and be no more opposed"}
+{"index":{"_index":"shakespeare","_id":18}}
+{"line_id":19,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.16","speaker":"KING HENRY IV","text_entry":"Against acquaintance, kindred and allies:"}
+{"index":{"_index":"shakespeare","_id":19}}
+{"line_id":20,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.17","speaker":"KING HENRY IV","text_entry":"The edge of war, like an ill-sheathed knife,"}
+{"index":{"_index":"shakespeare","_id":20}}
+{"line_id":21,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.18","speaker":"KING HENRY IV","text_entry":"No more shall cut his master. Therefore, friends,"}
+{"index":{"_index":"shakespeare","_id":21}}
+{"line_id":22,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.19","speaker":"KING HENRY IV","text_entry":"As far as to the sepulchre of Christ,"}
+{"index":{"_index":"shakespeare","_id":22}}
+{"line_id":23,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.20","speaker":"KING HENRY IV","text_entry":"Whose soldier now, under whose blessed cross"}
+{"index":{"_index":"shakespeare","_id":23}}
+{"line_id":24,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.21","speaker":"KING HENRY IV","text_entry":"We are impressed and engaged to fight,"}
+{"index":{"_index":"shakespeare","_id":24}}
+{"line_id":25,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.22","speaker":"KING HENRY IV","text_entry":"Forthwith a power of English shall we levy;"}
+{"index":{"_index":"shakespeare","_id":25}}
+{"line_id":26,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.23","speaker":"KING HENRY IV","text_entry":"Whose arms were moulded in their mothers womb"}
+{"index":{"_index":"shakespeare","_id":26}}
+{"line_id":27,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.24","speaker":"KING HENRY IV","text_entry":"To chase these pagans in those holy fields"}
+{"index":{"_index":"shakespeare","_id":27}}
+{"line_id":28,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.25","speaker":"KING HENRY IV","text_entry":"Over whose acres walkd those blessed feet"}
+{"index":{"_index":"shakespeare","_id":28}}
+{"line_id":29,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.26","speaker":"KING HENRY IV","text_entry":"Which fourteen hundred years ago were naild"}
+{"index":{"_index":"shakespeare","_id":29}}
+{"line_id":30,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.27","speaker":"KING HENRY IV","text_entry":"For our advantage on the bitter cross."}
+{"index":{"_index":"shakespeare","_id":30}}
+{"line_id":31,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.28","speaker":"KING HENRY IV","text_entry":"But this our purpose now is twelve month old,"}
+{"index":{"_index":"shakespeare","_id":31}}
+{"line_id":32,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.29","speaker":"KING HENRY IV","text_entry":"And bootless tis to tell you we will go:"}
+{"index":{"_index":"shakespeare","_id":32}}
+{"line_id":33,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.30","speaker":"KING HENRY IV","text_entry":"Therefore we meet not now. Then let me hear"}
+{"index":{"_index":"shakespeare","_id":33}}
+{"line_id":34,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.31","speaker":"KING HENRY IV","text_entry":"Of you, my gentle cousin Westmoreland,"}
+{"index":{"_index":"shakespeare","_id":34}}
+{"line_id":35,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.32","speaker":"KING HENRY IV","text_entry":"What yesternight our council did decree"}
+{"index":{"_index":"shakespeare","_id":35}}
+{"line_id":36,"play_name":"Henry IV","speech_number":1,"line_number":"1.1.33","speaker":"KING HENRY IV","text_entry":"In forwarding this dear expedience."}
+{"index":{"_index":"shakespeare","_id":36}}
+{"line_id":37,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.34","speaker":"WESTMORELAND","text_entry":"My liege, this haste was hot in question,"}
+{"index":{"_index":"shakespeare","_id":37}}
+{"line_id":38,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.35","speaker":"WESTMORELAND","text_entry":"And many limits of the charge set down"}
+{"index":{"_index":"shakespeare","_id":38}}
+{"line_id":39,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.36","speaker":"WESTMORELAND","text_entry":"But yesternight: when all athwart there came"}
+{"index":{"_index":"shakespeare","_id":39}}
+{"line_id":40,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.37","speaker":"WESTMORELAND","text_entry":"A post from Wales loaden with heavy news;"}
+{"index":{"_index":"shakespeare","_id":40}}
+{"line_id":41,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.38","speaker":"WESTMORELAND","text_entry":"Whose worst was, that the noble Mortimer,"}
+{"index":{"_index":"shakespeare","_id":41}}
+{"line_id":42,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.39","speaker":"WESTMORELAND","text_entry":"Leading the men of Herefordshire to fight"}
+{"index":{"_index":"shakespeare","_id":42}}
+{"line_id":43,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.40","speaker":"WESTMORELAND","text_entry":"Against the irregular and wild Glendower,"}
+{"index":{"_index":"shakespeare","_id":43}}
+{"line_id":44,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.41","speaker":"WESTMORELAND","text_entry":"Was by the rude hands of that Welshman taken,"}
+{"index":{"_index":"shakespeare","_id":44}}
+{"line_id":45,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.42","speaker":"WESTMORELAND","text_entry":"A thousand of his people butchered;"}
+{"index":{"_index":"shakespeare","_id":45}}
+{"line_id":46,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.43","speaker":"WESTMORELAND","text_entry":"Upon whose dead corpse there was such misuse,"}
+{"index":{"_index":"shakespeare","_id":46}}
+{"line_id":47,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.44","speaker":"WESTMORELAND","text_entry":"Such beastly shameless transformation,"}
+{"index":{"_index":"shakespeare","_id":47}}
+{"line_id":48,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.45","speaker":"WESTMORELAND","text_entry":"By those Welshwomen done as may not be"}
+{"index":{"_index":"shakespeare","_id":48}}
+{"line_id":49,"play_name":"Henry IV","speech_number":2,"line_number":"1.1.46","speaker":"WESTMORELAND","text_entry":"Without much shame retold or spoken of."}
+{"index":{"_index":"shakespeare","_id":49}}
+{"line_id":50,"play_name":"Henry IV","speech_number":3,"line_number":"1.1.47","speaker":"KING HENRY IV","text_entry":"It seems then that the tidings of this broil"}


### PR DESCRIPTION
This pull requests aims to add support in `uptasticsearch` for Elasticsearch 7.x. See the linked issue and changes to NEWS.md for details on what has changed in ES7.x.

This PR's scope is limited to "get `uptasticsearch` code working with Es7.x". It does not include taking advantage of any ES7-specific _features_ like new types of aggregations.

Opening this as a draft PR as it currently only addresses the R side. The Python side needs to be updated n this PR as well.