### PR TITLE
added python package stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ r-pkg/inst/testdata/*.json
 # Python stuff
 **/.pytest_cache/
 **/__pycache__/
+**/dist/
+**/htmlcov/
+**/*.egg-info/
 py-pkg/LICENSE
 py-pkg/NEWS.md
 py-pkg/README.md


### PR DESCRIPTION
I ran `cd py-pkg && python setup.py install` tonight trying to do some debugging on #161 . It left behind some things that we shouldn't be checking into the repo, but which are currently not ignored in `.gitignore`.

I propose we ignore them.