### PR TITLE
release v0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install_r: build_r
 	R CMD INSTALL r-pkg/
 
 test_r: build_r
-	R CMD CHECK uptasticsearch_*.tar.gz
+	R CMD CHECK --as-cran uptasticsearch_*.tar.gz
 
 ##########
 # Python #

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # uptasticsearch development version
 
+# uptasticsearch 0.4.0
+
 ## Features
 
 ### Added support for ES7.x

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-`uptasticsearch` tackles the issue of getting data out of Elasticsearch and into a tabular format in R and Python. It should work for all versions of Elasticsearch from 1.0.0 onwards, but [is not regularly tested against all of them](./CONTRIBUTING.md#travis). If you run into a problem, please [open an issue](https://github.com/uptake/uptasticsearch/issues).
+`uptasticsearch` tackles the issue of getting data out of Elasticsearch and into a tabular format in R and Python. It should work for all versions of Elasticsearch from 1.0.0 onwards, but [is not regularly tested against all of them](https://github.com/uptake/uptasticsearch/blob/master/CONTRIBUTING.md#travis). If you run into a problem, please [open an issue](https://github.com/uptake/uptasticsearch/issues).
 
 # Table of contents
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -130,4 +130,4 @@ In this submission, we changed maintainer from `james.lamb@uptake.com` to `jayla
 * No isses
 
 ### CRAN Response
-* TBD
+* No issues. v0.4.0 released to CRAN!

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -108,3 +108,11 @@
 
 ### CRAN Response
 * No issues. v0.3.1 released to CRAN!
+
+## v0.4.0 - Submission 1 - (September 9, 2019)
+
+### R CMD check results
+* No issues
+
+### CRAN Response
+* TBD

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -111,8 +111,14 @@
 
 ## v0.4.0 - Submission 1 - (September 9, 2019)
 
+In this submission, we changed maintainer from `james.lamb@uptake.com` to `jaylamb20@gmail.com`. Added this note in the initial submission:
+
+> This is a release to add support for Elasticsearch 7.x, a major release stream that has been General Availability since April 2019.
+
+> You may see that the maintainer email is changing from "james.lamb@uptake.com" to "jaylamb20@gmail.com". This is a contact info update only, not an actual maintainer change. The "uptake.com" address is tied to the company that holds copyright over this project (https://github.com/uptake/uptasticsearch/blob/master/LICENSE#L3). I no longer work there but have received their permission to continue on as the maintainer. If you need confirmation you can contact my coauthors who still work there (austin.dickey@uptake.com, nick.paras@uptake.com) or that company's legal team (dennis.lee@uptake.com) 
+
 ### R CMD check results
 * No issues
 
 ### CRAN Response
-* TBD
+* Release was auto-accepted, but the response email said "We are waiting for confirmation from the old maintainer address now.". I responded and re-iterated the message above about changed maintainer email. No response yet. We are blocked until they respond.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -9,7 +9,7 @@
 * local Windows 10, R 3.3.2
 * Windows via `devtools::build_win()`
 
-### R CMD check results
+### `R CMD check` results
 * There were no ERRORs, WARNINGs.  
 * One NOTE from `checking CRAN incoming feasibility ...` can be safely ignored since it's a note that notifies CRAN that this is a new maintainer/submission. 
 
@@ -30,7 +30,7 @@
 
 ## v0.1.0 - Submission 1 - (August 28, 2017)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -38,7 +38,7 @@
 
 ## v0.1.0 - Submission 2 - (August 28, 2017)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -46,7 +46,7 @@
 
 ## v0.1.0 - Submission 3 - (August 29, 2017)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -54,7 +54,7 @@
 
 ## v0.1.0 - Submission 4 - (August 29, 2017)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -63,7 +63,7 @@
 
 ## v0.1.0 - Submission 5 - (August 29, 2017)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -71,7 +71,7 @@
 
 ## v0.2.0 - Submission 1 - (April 12, 2018)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -79,7 +79,7 @@
 
 ## v0.3.0 - Submission 1 - (June 18, 2018)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -87,7 +87,7 @@
 
 ## v0.3.1 - Submission 1 - (January 28, 2019)
 
-### R CMD check results
+### `R CMD check` results
 * Issues on several platforms, of the form `premature EOF...`. This is a result of forgetting to put the test data in the package tarball before upload.
 
 ### CRAN Response
@@ -95,7 +95,7 @@
 
 ## v0.3.1 - Submission 2 - (January 29, 2019)
 
-### R CMD check results
+### `R CMD check` results
 * Empty links in `NEWS.md`
 
 ### CRAN Response
@@ -103,7 +103,7 @@
 
 ## v0.3.1 - Submission 3 - (January 30, 2019)
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
@@ -117,8 +117,17 @@ In this submission, we changed maintainer from `james.lamb@uptake.com` to `jayla
 
 > You may see that the maintainer email is changing from "james.lamb@uptake.com" to "jaylamb20@gmail.com". This is a contact info update only, not an actual maintainer change. The "uptake.com" address is tied to the company that holds copyright over this project (https://github.com/uptake/uptasticsearch/blob/master/LICENSE#L3). I no longer work there but have received their permission to continue on as the maintainer. If you need confirmation you can contact my coauthors who still work there (austin.dickey@uptake.com, nick.paras@uptake.com) or that company's legal team (dennis.lee@uptake.com) 
 
-### R CMD check results
+### `R CMD check` results
 * No issues
 
 ### CRAN Response
 * Release was auto-accepted, but the response email said "We are waiting for confirmation from the old maintainer address now.". I responded and re-iterated the message above about changed maintainer email. No response yet. We are blocked until they respond.
+* CRAN seems ok with the maintainer change, noted that we have one bad link in `README.md`, "`./CONTRIBUTING.md"`. Needs to be changed to a fully-specified URL.
+
+## v0.4.0 - Submission 1 - (September 11, 2019)
+
+### `R CMD check` results
+* No isses
+
+### CRAN Response
+* TBD

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/articles/FAQ.html
+++ b/docs/articles/FAQ.html
@@ -30,7 +30,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 
@@ -83,7 +83,7 @@
       <h1>Frequently Asked Questions</h1>
                         <h4 class="author">Stephanie Kirmer</h4>
             
-            <h4 class="date">2019-01-31</h4>
+            <h4 class="date">2019-09-09</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/uptake/uptasticsearch/blob/master/../vignettes/FAQ.Rmd"><code>../vignettes/FAQ.Rmd</code></a></small>
       <div class="hidden name"><code>FAQ.Rmd</code></div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 
@@ -94,37 +94,29 @@
 <div id="introduction" class="section level2">
 <h2 class="hasAnchor">
 <a href="#introduction" class="anchor"></a>Introduction</h2>
-<p>This project tackles the issue of getting data out of Elasticsearch and into a tabular format in R.</p>
+<p><code>uptasticsearch</code> tackles the issue of getting data out of Elasticsearch and into a tabular format in R and Python. It should work for all versions of Elasticsearch from 1.0.0 onwards, but <a href="./CONTRIBUTING.md#travis">is not regularly tested against all of them</a>. If you run into a problem, please <a href="https://github.com/uptake/uptasticsearch/issues">open an issue</a>.</p>
 </div>
 </div>
 <div id="table-of-contents" class="section level1">
 <h1 class="hasAnchor">
 <a href="#table-of-contents" class="anchor"></a>Table of contents</h1>
-<ol>
+<ul>
 <li><a href="#howitworks">How it Works</a></li>
 <li>
 <a href="#installation">Installation</a>
-<ol>
+<ul>
 <li><a href="#rinstallation">R</a></li>
 <li><a href="#pythoninstallation">Python</a></li>
-</ol>
+</ul>
 </li>
 <li>
 <a href="#examples">Usage Examples</a>
-<ol>
+<ul>
 <li><a href="#example1">Get a Batch of Documents</a></li>
 <li><a href="#example2">Aggregation Results</a></li>
-</ol>
+</ul>
 </li>
-<li>
-<a href="#nextsteps">Next Steps</a>
-<ol>
-<li><a href="#authsupport">Auth Support</a></li>
-</ol>
-</li>
-<li><a href="#local-tests">Running Tests Locally</a></li>
-<li><a href="#the-site">Regenerating the Documentation Site</a></li>
-</ol>
+</ul>
 <div id="how-it-works" class="section level2">
 <h2 class="hasAnchor">
 <a href="#how-it-works" class="anchor"></a>How it Works <a name="howitworks"></a>
@@ -140,9 +132,15 @@
 <a href="#r" class="anchor"></a>R <a name="rinstallation"></a>
 </h3>
 <p>Releases of this package can be installed from CRAN:</p>
-<pre><code><a href="https://www.rdocumentation.org/packages/utils/topics/install.packages">install.packages('uptasticsearch')</a></code></pre>
+<pre><code><a href="https://www.rdocumentation.org/packages/utils/topics/install.packages">install.packages(
+  'uptasticsearch'
+  , repos = "http://cran.rstudio.com"
+)</a></code></pre>
 <p>To use the development version of the package, which has the newest changes, you can install directly from GitHub</p>
-<pre><code><a href="https://www.rdocumentation.org/packages/devtools/topics/install_github">devtools::install_github("uptake/uptasticsearch", subdir = "r-pkg")</a></code></pre>
+<pre><code><a href="https://www.rdocumentation.org/packages/devtools/topics/reexports">devtools::install_github(
+  "uptake/uptasticsearch"
+  , subdir = "r-pkg"
+)</a></code></pre>
 </div>
 <div id="python" class="section level3">
 <h3 class="hasAnchor">
@@ -454,9 +452,9 @@ revenueDT &lt;- es_search(
   <div class="dev-status">
 <h2>Dev status</h2>
 <ul class="list-unstyled">
+<li><a href="https://travis-ci.org/uptake/uptasticsearch"><img src="https://img.shields.io/travis/uptake/uptasticsearch.svg?label=travis&amp;logo=travis&amp;branch=master" alt="Travis Build Status"></a></li>
 <li><a href="https://cran.r-project.org/package=uptasticsearch"><img src="https://www.r-pkg.org/badges/version-last-release/uptasticsearch" alt="CRAN_Status_Badge"></a></li>
 <li><a href="https://cran.r-project.org/package=uptasticsearch"><img src="https://cranlogs.r-pkg.org/badges/grand-total/uptasticsearch" alt="CRAN_Download_Badge"></a></li>
-<li><a href="https://travis-ci.org/uptake/uptasticsearch"><img src="https://travis-ci.org/uptake/uptasticsearch.svg?branch=master" alt="Build Status"></a></li>
 </ul>
 </div>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 
@@ -115,6 +115,23 @@
       <small>Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="uptasticsearch-0-4-0" class="section level1">
+<h1 class="page-header">
+<a href="#uptasticsearch-0-4-0" class="anchor"></a>uptasticsearch 0.4.0<small> Unreleased </small>
+</h1>
+<div id="features" class="section level2">
+<h2 class="hasAnchor">
+<a href="#features" class="anchor"></a>Features</h2>
+<div id="added-support-for-es7-x" class="section level3">
+<h3 class="hasAnchor">
+<a href="#added-support-for-es7-x" class="anchor"></a>Added support for ES7.x</h3>
+<ul>
+<li>
+<a href="https://github.com/uptake/uptasticsearch/pull/161"><a href='https://github.com/uptake/uptasticsearch/issues/161'>#161</a></a> Added support for ES7.x. The biggest changes between that major version and 6.x were the removal of <code>_all</code> as a way to reference all indices, changing the response format of <code>hits.total</code> into an object like <code>{"hits": {"total": 50}}</code>, and restricting all indices to have a single type of document. More details can be found at <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html" class="uri">https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html</a>.</li>
+</ul>
+</div>
+</div>
+</div>
     <div id="uptasticsearch-0-3-1" class="section level1">
 <h1 class="page-header">
 <a href="#uptasticsearch-0-3-1" class="anchor"></a>uptasticsearch 0.3.1<small> 2019-01-30 </small>
@@ -144,9 +161,9 @@
 <h1 class="page-header">
 <a href="#uptasticsearch-0-3-0" class="anchor"></a>uptasticsearch 0.3.0<small> 2018-06-19 </small>
 </h1>
-<div id="features" class="section level2">
+<div id="features-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features" class="anchor"></a>Features</h2>
+<a href="#features-1" class="anchor"></a>Features</h2>
 <div id="full-support-for-es6-x" class="section level3">
 <h3 class="hasAnchor">
 <a href="#full-support-for-es6-x" class="anchor"></a>Full support for ES6.x</h3>
@@ -203,9 +220,9 @@
 <h1 class="page-header">
 <a href="#uptasticsearch-0-2-0" class="anchor"></a>uptasticsearch 0.2.0<small> 2018-04-13 </small>
 </h1>
-<div id="features-1" class="section level2">
+<div id="features-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-1" class="anchor"></a>Features</h2>
+<a href="#features-2" class="anchor"></a>Features</h2>
 <div id="faster-unpack_nested_data" class="section level3">
 <h3 class="hasAnchor">
 <a href="#faster-unpack_nested_data" class="anchor"></a>Faster <code>unpack_nested_data</code>
@@ -228,9 +245,9 @@
 <h1 class="page-header">
 <a href="#uptasticsearch-0-1-0" class="anchor"></a>uptasticsearch 0.1.0<small> 2017-08-29 </small>
 </h1>
-<div id="features-2" class="section level2">
+<div id="features-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-2" class="anchor"></a>Features</h2>
+<a href="#features-3" class="anchor"></a>Features</h2>
 <div id="elasticsearch-metadata" class="section level3">
 <h3 class="hasAnchor">
 <a href="#elasticsearch-metadata" class="anchor"></a>Elasticsearch metadata</h3>
@@ -264,9 +281,9 @@
 <h1 class="page-header">
 <a href="#uptasticsearch-0-0-2" class="anchor"></a>uptasticsearch 0.0.2<small> 2017-07-18 </small>
 </h1>
-<div id="features-3" class="section level2">
+<div id="features-4" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-3" class="anchor"></a>Features</h2>
+<a href="#features-4" class="anchor"></a>Features</h2>
 <div id="main-function" class="section level3">
 <h3 class="hasAnchor">
 <a href="#main-function" class="anchor"></a>Main function</h3>
@@ -311,6 +328,7 @@
     <div id="tocnav">
       <h2>Contents</h2>
       <ul class="nav nav-pills nav-stacked">
+        <li><a href="#uptasticsearch-0-4-0">0.4.0</a></li>
         <li><a href="#uptasticsearch-0-3-1">0.3.1</a></li>
         <li><a href="#uptasticsearch-0-3-0">0.3.0</a></li>
         <li><a href="#uptasticsearch-0-2-0">0.2.0</a></li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: 1.19.2.1
+pandoc: 2.3.1
 pkgdown: 1.3.0
 pkgdown_sha: ~
 articles:

--- a/docs/reference/chomp_aggs.html
+++ b/docs/reference/chomp_aggs.html
@@ -64,7 +64,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/reference/chomp_hits.html
+++ b/docs/reference/chomp_hits.html
@@ -65,7 +65,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 
@@ -164,7 +164,7 @@ columns are deleted.</p></td>
 "film":"Avengers: Infinity War","pmt_amount":12.75}]}}}]'</span>
 
 <span class='co'># Chomp into a data.table</span>
-<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2019-01-31 19:53:06] Keeping the following nested data columns. Consider using unpack_nested_data for one:
+<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2019-09-09 21:22:29] Keeping the following nested data columns. Consider using unpack_nested_data for one:
 #&gt;  details.pastPurchases</div><div class='input'><span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
 #&gt; 1: 2017-01-01    Austin        big_spender          chicago
 #&gt; 2: 2017-02-02     James            peasant          chicago

--- a/docs/reference/doc_shared.html
+++ b/docs/reference/doc_shared.html
@@ -64,7 +64,7 @@ inheritParams" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/reference/es_search.html
+++ b/docs/reference/es_search.html
@@ -65,7 +65,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/reference/get_fields.html
+++ b/docs/reference/get_fields.html
@@ -64,7 +64,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/reference/parse_date_time.html
+++ b/docs/reference/parse_date_time.html
@@ -68,7 +68,7 @@ This is a side-effect-free function: it returns a new data.table and the
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 

--- a/docs/reference/unpack_nested_data.html
+++ b/docs/reference/unpack_nested_data.html
@@ -69,7 +69,7 @@ This is a side-effect-free function: it returns a new data.table and the
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.3.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
       </span>
     </div>
 
@@ -169,7 +169,7 @@ unpack</p></td>
 "film":"Avengers: Infinity War","pmt_amount":12.75}]}}}]'</span>
 
 <span class='co'># Chomp into a data.table</span>
-<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='chomp_hits.html'>chomp_hits</a></span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2019-01-31 19:53:07] Keeping the following nested data columns. Consider using unpack_nested_data for one:
+<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='chomp_hits.html'>chomp_hits</a></span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2019-09-09 21:22:30] Keeping the following nested data columns. Consider using unpack_nested_data for one:
 #&gt;  details.pastPurchases</div><div class='input'><span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
 #&gt; 1: 2017-01-01    Austin        big_spender          chicago
 #&gt; 2: 2017-02-02     James            peasant          chicago

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: uptasticsearch
 Type: Package
 Title: Get Data Frame Representations of 'Elasticsearch' Results
-Version: 0.4.1
+Version: 0.4.0
 Authors@R: c(
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut", "cre")),
     person("Nick", "Paras", email = "nick.paras@uptake.com", role = c("aut")),
@@ -33,8 +33,8 @@ Imports:
     uuid
 Suggests:
     knitr,
-    testthat,
-    rmarkdown
+    rmarkdown,
+    testthat
 License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/uptasticsearch
 BugReports: https://github.com/uptake/uptasticsearch/issues


### PR DESCRIPTION
I think it is time to do another release of the R package to CRAN!

The only user-facing change in this release is #161, which adds much-needed support Elasticsearch 7.x ([available since April of this year](https://github.com/elastic/elasticsearch/releases/tag/v7.0.0)).

@austin3dickey I haven't actually submitted to CRAN yet, want to see if you're ok with it.