### PR TITLE
Properly show functions for inline-md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,26 +32,26 @@
 
 ## Bugfixes
 
-### `get_fields` when your index has no aliases
-- previously, `get_fields` broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the `_cat/aliases` endpoint has changed from major version to major version. [#66](https://github.com/uptake/uptasticsearch/pull/66) fixed this for all major versions of ES from 1.0 to 6.2
+### `get_fields()` when your index has no aliases
+- previously, `get_fields()` broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the `_cat/aliases` endpoint has changed from major version to major version. [#66](https://github.com/uptake/uptasticsearch/pull/66) fixed this for all major versions of ES from 1.0 to 6.2
 
-### `get_fields` when your index has multiple aliases
-- previously, if you had multiple aliases pointing to the same physical index, `get_fields` would only return one of those. As of [#73](https://github.com/uptake/uptasticsearch/pull/73), mappings for the underlying physical index will now be duplicated once per alias in the table returned by `get_fields`.
+### `get_fields()` when your index has multiple aliases
+- previously, if you had multiple aliases pointing to the same physical index, `get_fields()` would only return one of those. As of [#73](https://github.com/uptake/uptasticsearch/pull/73), mappings for the underlying physical index will now be duplicated once per alias in the table returned by `get_fields()`.
 
 ### bad parsing of ES major version
 - as of [#64](https://github.com/uptake/uptasticsearch/pull/64), `uptasticsearch` attempts to query the ES host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in [#66](https://github.com/uptake/uptasticsearch/pull/66). NOTE: this only impacted the dev version of the library on Github.
 
 ### `ignore_scroll_restriction` not being respected
-- In previous versions of `uptasticsearch`, the value passed to `es_search` for `ignore_scroll_restriction` was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn't getting passed through. [#66](https://github.com/uptake/uptasticsearch/pull/66) instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won't be able to silently get through testing in the future.
+- In previous versions of `uptasticsearch`, the value passed to `es_search()` for `ignore_scroll_restriction` was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn't getting passed through. [#66](https://github.com/uptake/uptasticsearch/pull/66) instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won't be able to silently get through testing in the future.
 
 ## Deprecations and Removals
-- [#69](https://github.com/uptake/uptasticsearch/pull/69) added a deprecation warning on `get_counts`. This function was outside the core mission of the package and exposed us unnecessarily to changes in the Elasticsearch DSL
+- [#69](https://github.com/uptake/uptasticsearch/pull/69) added a deprecation warning on `get_counts()`. This function was outside the core mission of the package and exposed us unnecessarily to changes in the Elasticsearch DSL
 
 # uptasticsearch 0.2.0
 
 ## Features
 
-### Faster `unpack_nested_data`
+### Faster `unpack_nested_data()`
 - [#51](https://github.com/uptake/uptasticsearch/pull/51) changed the parsing strategy for nested data and made it 9x faster than the previous implementation
 
 ### Retry logic
@@ -62,10 +62,10 @@
 ## Features
 
 ### Elasticsearch metadata
-- `get_fields` returns a data.table with the names and types of all indexed fields across one or more indices
+- `get_fields()` returns a data.table with the names and types of all indexed fields across one or more indices
 
 ### Routing Temporary File Writing
-- `es_search` now accepts an `intermediates_dir` parameter, giving users control over the directory used for temporary I/O at query time
+- `es_search()` now accepts an `intermediates_dir` parameter, giving users control over the directory used for temporary I/O at query time
 
 ## Bugfixes
 
@@ -77,15 +77,15 @@
 ## Features
 
 ### Main function
-- `es_search` executes an ES query and gets a data.table
+- `es_search()` executes an ES query and gets a data.table
 
 ### Parse raw JSON into data.table
-- `chomp_aggs` converts a raw aggs JSON to data.table
-- `chomp_hits` converts a raw hits JSON to data.table
+- `chomp_aggs()` converts a raw aggs JSON to data.table
+- `chomp_hits()` converts a raw hits JSON to data.table
 
 ### Utilities
-- `unpack_nested_data` deals with nested Elasticsearch data not in a tabular format
-- `parse_date_time` parses date-times from Elasticsearch records
+- `unpack_nested_data()` deals with nested Elasticsearch data not in a tabular format
+- `parse_date_time()` parses date-times from Elasticsearch records
 
 ### Exploratory functions
-- `get_counts` examines the distribution of distinct values for a field in Elasticsearch
+- `get_counts()` examines the distribution of distinct values for a field in Elasticsearch

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## How it Works <a name="howitworks"></a>
 
-The core functionality of this package is the `es_search` function. This returns a `data.table` containing the parsed result of any given query. Note that this includes `aggs` queries.
+The core functionality of this package is the `es_search()` function. This returns a `data.table` containing the parsed result of any given query. Note that this includes `aggs` queries.
 
 ## Installation <a name="installation"></a>
 
@@ -159,7 +159,7 @@ revenueDT <- es_search(
 )
 ```
 
-In the example above, we used the [date_histogram](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html) and [extended_stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html) aggregations. `es_search` has built-in support for many other aggregations and combinations of aggregations, with more on the way. Please see the table below for the current status of the package. Note that names of the form "agg1 - agg2" refer to the ability to handled aggregations nested inside other aggregations.
+In the example above, we used the [date_histogram](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html) and [extended_stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html) aggregations. `es_search()` has built-in support for many other aggregations and combinations of aggregations, with more on the way. Please see the table below for the current status of the package. Note that names of the form "agg1 - agg2" refer to the ability to handled aggregations nested inside other aggregations.
 
 |Agg type                                     | R support?  | Python support?  |
 |:--------------------------------------------|:-----------:|:----------------:|

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
 <h2 class="hasAnchor">
 <a href="#how-it-works" class="anchor"></a>How it Works <a name="howitworks"></a>
 </h2>
-<p>The core functionality of this package is the <code>es_search</code> function. This returns a <code>data.table</code> containing the parsed result of any given query. Note that this includes <code>aggs</code> queries.</p>
+<p>The core functionality of this package is the <code>es_search()</code> function. This returns a <code>data.table</code> containing the parsed result of any given query. Note that this includes <code>aggs</code> queries.</p>
 </div>
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
@@ -253,7 +253,7 @@ revenueDT &lt;- es_search(
     , query_body = qbody
     , n_cores = 1
 )</a></code></pre>
-<p>In the example above, we used the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html">date_histogram</a> and <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html">extended_stats</a> aggregations. <code>es_search</code> has built-in support for many other aggregations and combinations of aggregations, with more on the way. Please see the table below for the current status of the package. Note that names of the form “agg1 - agg2” refer to the ability to handled aggregations nested inside other aggregations.</p>
+<p>In the example above, we used the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html">date_histogram</a> and <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html">extended_stats</a> aggregations. <code>es_search()</code> has built-in support for many other aggregations and combinations of aggregations, with more on the way. Please see the table below for the current status of the package. Note that names of the form “agg1 - agg2” refer to the ability to handled aggregations nested inside other aggregations.</p>
 <table class="table">
 <thead><tr class="header">
 <th align="left">Agg type</th>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -180,16 +180,16 @@
 <a href="#bugfixes-1" class="anchor"></a>Bugfixes</h2>
 <div id="get_fields-when-your-index-has-no-aliases" class="section level3">
 <h3 class="hasAnchor">
-<a href="#get_fields-when-your-index-has-no-aliases" class="anchor"></a><code>get_fields</code> when your index has no aliases</h3>
+<a href="#get_fields-when-your-index-has-no-aliases" class="anchor"></a><code>get_fields()</code> when your index has no aliases</h3>
 <ul>
-<li>previously, <code>get_fields</code> broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the <code>_cat/aliases</code> endpoint has changed from major version to major version. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> fixed this for all major versions of ES from 1.0 to 6.2</li>
+<li>previously, <code>get_fields()</code> broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the <code>_cat/aliases</code> endpoint has changed from major version to major version. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> fixed this for all major versions of ES from 1.0 to 6.2</li>
 </ul>
 </div>
 <div id="get_fields-when-your-index-has-multiple-aliases" class="section level3">
 <h3 class="hasAnchor">
-<a href="#get_fields-when-your-index-has-multiple-aliases" class="anchor"></a><code>get_fields</code> when your index has multiple aliases</h3>
+<a href="#get_fields-when-your-index-has-multiple-aliases" class="anchor"></a><code>get_fields()</code> when your index has multiple aliases</h3>
 <ul>
-<li>previously, if you had multiple aliases pointing to the same physical index, <code>get_fields</code> would only return one of those. As of <a href="https://github.com/uptake/uptasticsearch/pull/73"><a href='https://github.com/uptake/uptasticsearch/issues/73'>#73</a></a>, mappings for the underlying physical index will now be duplicated once per alias in the table returned by <code>get_fields</code>.</li>
+<li>previously, if you had multiple aliases pointing to the same physical index, <code>get_fields()</code> would only return one of those. As of <a href="https://github.com/uptake/uptasticsearch/pull/73"><a href='https://github.com/uptake/uptasticsearch/issues/73'>#73</a></a>, mappings for the underlying physical index will now be duplicated once per alias in the table returned by <code>get_fields()</code>.</li>
 </ul>
 </div>
 <div id="bad-parsing-of-es-major-version" class="section level3">
@@ -203,7 +203,7 @@
 <h3 class="hasAnchor">
 <a href="#ignore_scroll_restriction-not-being-respected" class="anchor"></a><code>ignore_scroll_restriction</code> not being respected</h3>
 <ul>
-<li>In previous versions of <code>uptasticsearch</code>, the value passed to <code>es_search</code> for <code>ignore_scroll_restriction</code> was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn’t getting passed through. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won’t be able to silently get through testing in the future.</li>
+<li>In previous versions of <code>uptasticsearch</code>, the value passed to <code>es_search()</code> for <code>ignore_scroll_restriction</code> was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn’t getting passed through. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won’t be able to silently get through testing in the future.</li>
 </ul>
 </div>
 </div>
@@ -225,7 +225,7 @@
 <a href="#features-2" class="anchor"></a>Features</h2>
 <div id="faster-unpack_nested_data" class="section level3">
 <h3 class="hasAnchor">
-<a href="#faster-unpack_nested_data" class="anchor"></a>Faster <code>unpack_nested_data</code>
+<a href="#faster-unpack_nested_data" class="anchor"></a>Faster <code>unpack_nested_data()</code>
 </h3>
 <ul>
 <li>
@@ -253,7 +253,7 @@
 <a href="#elasticsearch-metadata" class="anchor"></a>Elasticsearch metadata</h3>
 <ul>
 <li>
-<code>get_fields</code> returns a data.table with the names and types of all indexed fields across one or more indices</li>
+<code>get_fields()</code> returns a data.table with the names and types of all indexed fields across one or more indices</li>
 </ul>
 </div>
 <div id="routing-temporary-file-writing" class="section level3">
@@ -261,7 +261,7 @@
 <a href="#routing-temporary-file-writing" class="anchor"></a>Routing Temporary File Writing</h3>
 <ul>
 <li>
-<code>es_search</code> now accepts an <code>intermediates_dir</code> parameter, giving users control over the directory used for temporary I/O at query time</li>
+<code>es_search()</code> now accepts an <code>intermediates_dir</code> parameter, giving users control over the directory used for temporary I/O at query time</li>
 </ul>
 </div>
 </div>
@@ -289,7 +289,7 @@
 <a href="#main-function" class="anchor"></a>Main function</h3>
 <ul>
 <li>
-<code>es_search</code> executes an ES query and gets a data.table</li>
+<code>es_search()</code> executes an ES query and gets a data.table</li>
 </ul>
 </div>
 <div id="parse-raw-json-into-data-table" class="section level3">
@@ -297,9 +297,9 @@
 <a href="#parse-raw-json-into-data-table" class="anchor"></a>Parse raw JSON into data.table</h3>
 <ul>
 <li>
-<code>chomp_aggs</code> converts a raw aggs JSON to data.table</li>
+<code>chomp_aggs()</code> converts a raw aggs JSON to data.table</li>
 <li>
-<code>chomp_hits</code> converts a raw hits JSON to data.table</li>
+<code>chomp_hits()</code> converts a raw hits JSON to data.table</li>
 </ul>
 </div>
 <div id="utilities" class="section level3">
@@ -307,9 +307,9 @@
 <a href="#utilities" class="anchor"></a>Utilities</h3>
 <ul>
 <li>
-<code>unpack_nested_data</code> deals with nested Elasticsearch data not in a tabular format</li>
+<code>unpack_nested_data()</code> deals with nested Elasticsearch data not in a tabular format</li>
 <li>
-<code>parse_date_time</code> parses date-times from Elasticsearch records</li>
+<code>parse_date_time()</code> parses date-times from Elasticsearch records</li>
 </ul>
 </div>
 <div id="exploratory-functions" class="section level3">
@@ -317,7 +317,7 @@
 <a href="#exploratory-functions" class="anchor"></a>Exploratory functions</h3>
 <ul>
 <li>
-<code>get_counts</code> examines the distribution of distinct values for a field in Elasticsearch</li>
+<code>get_counts()</code> examines the distribution of distinct values for a field in Elasticsearch</li>
 </ul>
 </div>
 </div>

--- a/docs/reference/chomp_aggs.html
+++ b/docs/reference/chomp_aggs.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Aggs query to data.table — chomp_aggs • uptasticsearch</title>
+<title>Aggs query to data.table — chomp_aggs() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="Aggs query to data.table — chomp_aggs" />
+<meta property="og:title" content="Aggs query to data.table — chomp_aggs()" />
 
 <meta property="og:description" content="Given some raw JSON from an aggs query in Elasticsearch, parse the
              aggregations into a data.table." />

--- a/docs/reference/chomp_hits.html
+++ b/docs/reference/chomp_hits.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Hits to data.tables — chomp_hits • uptasticsearch</title>
+<title>Hits to data.tables — chomp_hits() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="Hits to data.tables — chomp_hits" />
+<meta property="og:title" content="Hits to data.tables — chomp_hits()" />
 
 <meta property="og:description" content="A function for converting Elasticsearch docs into R data.tables. It
              uses fromJSON with flatten = TRUE to convert a

--- a/docs/reference/es_search.html
+++ b/docs/reference/es_search.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Execute an ES query and get a data.table — es_search • uptasticsearch</title>
+<title>Execute an ES query and get a data.table — es_search() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,9 +30,9 @@
 
 
 
-<meta property="og:title" content="Execute an ES query and get a data.table — es_search" />
+<meta property="og:title" content="Execute an ES query and get a data.table — es_search()" />
 
-<meta property="og:description" content="Given a query and some optional parameters, es_search gets results
+<meta property="og:description" content="Given a query and some optional parameters, es_search() gets results
              from HTTP requests to Elasticsearch and returns a data.table
              representation of those results." />
 <meta name="twitter:card" content="summary" />
@@ -123,7 +123,7 @@
 
     <div class="ref-description">
     
-    <p>Given a query and some optional parameters, <code>es_search</code> gets results
+    <p>Given a query and some optional parameters, <code>es_search()</code> gets results
              from HTTP requests to Elasticsearch and returns a data.table
              representation of those results.</p>
     
@@ -174,7 +174,7 @@ for more information.</p></td>
     </tr>
     <tr>
       <th>max_hits</th>
-      <td><p>Integer. If specified, <code>es_search</code> will stop pulling data as soon
+      <td><p>Integer. If specified, <code>es_search()</code> will stop pulling data as soon
 as it has pulled this many hits. Default is <code>Inf</code>, meaning that
 all possible hits will be pulled.</p></td>
     </tr>
@@ -184,7 +184,7 @@ all possible hits will be pulled.</p></td>
     </tr>
     <tr>
       <th>break_on_duplicates</th>
-      <td><p>Boolean, defaults to TRUE. <code>es_search</code> uses the size of the final object it returns
+      <td><p>Boolean, defaults to TRUE. <code>es_search()</code> uses the size of the final object it returns
 to check whether or not some data were lost during the processing.
 If you have duplicates in the source data, you will have to set this flag to
 FALSE and just trust that no data have been lost. Sorry :( .</p></td>
@@ -204,9 +204,9 @@ to <code>TRUE</code>.</p></td>
     <tr>
       <th>intermediates_dir</th>
       <td><p>When scrolling over search results, this function writes
-intermediate results to disk. By default, `es_search` will create a temporary
+intermediate results to disk. By default, <code>es_search()</code> will create a temporary
 directory in whatever working directory the function is called from. If you
-want to change this behavior, provide a path here. `es_search` will create
+want to change this behavior, provide a path here. <code>es_search()</code> will create
 and write to a temporary directory under whatever path you provide.</p></td>
     </tr>
     </table>

--- a/docs/reference/get_counts.html
+++ b/docs/reference/get_counts.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Examine the distribution of distinct values for a field in Elasticsearch — get_counts • uptasticsearch</title>
+<title>Examine the distribution of distinct values for a field in Elasticsearch — get_counts() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="Examine the distribution of distinct values for a field in Elasticsearch — get_counts" />
+<meta property="og:title" content="Examine the distribution of distinct values for a field in Elasticsearch — get_counts()" />
 
 <meta property="og:description" content="For a given field, return a data.table with its unique values in a time range." />
 <meta name="twitter:card" content="summary" />

--- a/docs/reference/get_fields.html
+++ b/docs/reference/get_fields.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get the names and data types of the indexed fields in an index — get_fields • uptasticsearch</title>
+<title>Get the names and data types of the indexed fields in an index — get_fields() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="Get the names and data types of the indexed fields in an index — get_fields" />
+<meta property="og:title" content="Get the names and data types of the indexed fields in an index — get_fields()" />
 
 <meta property="og:description" content="For a given Elasticsearch index, return the mapping from field name
              to data type for all indexed fields." />

--- a/docs/reference/parse_date_time.html
+++ b/docs/reference/parse_date_time.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Parse date-times from Elasticsearch records — parse_date_time • uptasticsearch</title>
+<title>Parse date-times from Elasticsearch records — parse_date_time() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="Parse date-times from Elasticsearch records — parse_date_time" />
+<meta property="og:title" content="Parse date-times from Elasticsearch records — parse_date_time()" />
 
 <meta property="og:description" content="Given a data.table with date-time strings,
              this function converts those dates-times to type POSIXct with the appropriate

--- a/docs/reference/unpack_nested_data.html
+++ b/docs/reference/unpack_nested_data.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Unpack a nested data.table — unpack_nested_data • uptasticsearch</title>
+<title>Unpack a nested data.table — unpack_nested_data() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -32,7 +32,7 @@
 
 <meta property="og:title" content="Unpack a nested data.table — unpack_nested_data" />
 
-<meta property="og:description" content="After calling a chomp_* function or es_search, if
+<meta property="og:description" content="After calling a chomp_*() function or es_search(), if
   you had a nested array in the JSON, its corresponding column in the
   resulting data.table is a data.frame itself (or a list of vectors). This
   function expands that nested column out, adding its data to the original
@@ -127,7 +127,7 @@ This is a side-effect-free function: it returns a new data.table and the
 
     <div class="ref-description">
     
-    <p>After calling a <code>chomp_*</code> function or <code>es_search</code>, if
+    <p>After calling a <code>chomp_*()</code> function or <code>es_search()</code>, if
   you had a nested array in the JSON, its corresponding column in the
   resulting data.table is a data.frame itself (or a list of vectors). This
   function expands that nested column out, adding its data to the original


### PR DESCRIPTION
# Fix functions that are in-line to properly shown as such
Fixes #191 

References to function names in markdown and html documentation have been corrected to properly show as functions instead of variables or attributes


Fairly certain all references have been changed that needed to