### PR TITLE
[ci] updated Elasticsearch versions in CI and docs

### DIFF
--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -90,7 +90,7 @@ case "$ES_VERSION" in
       export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
       ;;
 
-    "7.4.2")
+    "7.5.2")
       export MAPPING_FILE=${ES7_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
       # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data

--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -30,12 +30,12 @@ case "$ES_VERSION" in
       export ES_BINARY_URL="${ES1_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
-    "1.7.5")
+    "1.7.6")
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES1_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
-    "2.4.2")
+    "2.4.6")
       export MAPPING_FILE=${LEGACY_MAPPING_FILE};
       export ES_BINARY_URL="${ES2_ARCHIVE}/$ES_VERSION/elasticsearch-$ES_VERSION.deb"
       ;;
@@ -50,7 +50,7 @@ case "$ES_VERSION" in
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
-    "6.8.2")
+    "6.8.6")
       export MAPPING_FILE=${ES6_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
@@ -76,7 +76,21 @@ case "$ES_VERSION" in
       export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
       ;;
 
-    "7.3.1")
+    "7.3.2")
+      export MAPPING_FILE=${ES7_MAPPING_FILE};
+      export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
+      # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data
+      export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
+      ;;
+
+    "7.4.2")
+      export MAPPING_FILE=${ES7_MAPPING_FILE};
+      export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
+      # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data
+      export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
+      ;;
+
+    "7.4.2")
       export MAPPING_FILE=${ES7_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
       # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ matrix:
       warnings_are_errors: true
       cache: packages
       env:
-        - ES_VERSION=1.7.5
+        - ES_VERSION=1.7.6
         - TASK=rpkg
     - language: r
       warnings_are_errors: true
       cache: packages
       env:
-        - ES_VERSION=2.4.2
+        - ES_VERSION=2.4.6
         - TASK=rpkg
     - language: r
       warnings_are_errors: true
@@ -52,7 +52,7 @@ matrix:
       warnings_are_errors: true
       cache: packages
       env:
-        - ES_VERSION=6.8.2
+        - ES_VERSION=6.8.6
         - TASK=rpkg
     - language: r
       warnings_are_errors: true
@@ -76,7 +76,19 @@ matrix:
       warnings_are_errors: true
       cache: packages
       env:
-        - ES_VERSION=7.3.1
+        - ES_VERSION=7.3.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.4.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.5.2
         - TASK=rpkg
       after_success:
         - .ci/report_to_covr.sh
@@ -91,12 +103,12 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - ES_VERSION=1.7.5
+        - ES_VERSION=1.7.6
         - TASK=pypkg
     - language: python
       python: 3.5
       env:
-        - ES_VERSION=2.4.2
+        - ES_VERSION=2.4.6
         - TASK=pypkg
     - language: python
       python: 3.5
@@ -111,7 +123,7 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - ES_VERSION=6.8.2
+        - ES_VERSION=6.8.6
         - TASK=pypkg
     - language: python
       python: 3.5
@@ -131,5 +143,15 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - ES_VERSION=7.3.1
+        - ES_VERSION=7.3.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=7.4.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=7.5.2
         - TASK=pypkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,18 +88,20 @@ The set of Elasticsearch versions this project tests against changes regularly a
 
 > `uptasticsearch` may be tested against specific additional intermediate versions if bugs are found in the interaction between `uptasticsearch` and those versions
 
-So, for example, as of September 2019 that meant we tested against:
+So, for example, as of January 2020 that meant we tested against:
 
 * 1.0.0
-* 1.7.5
-* 2.4.2
+* 1.7.6
+* 2.4.6
 * 5.6.16
 * 6.0.1
-* 6.8.2
+* 6.8.6
 * 7.0.1
 * 7.1.1
 * 7.2.1
-* 7.3.1
+* 7.3.2
+* 7.4.2
+* 7.5.2
 
 You may notice that this strategy means that `uptasticsearch` is tested for backwards compatibility with Elasticsearch versions which have already reached [End-of-Life](https://www.elastic.co/support/eol). For example, support for Elasticsearch 1.7.x officially ended in January 2017. We test these old versions because we know of users whose companies still run those versions, and for whom Elasticsearch upgrades are prohibitively expensive. In general, upgrades across major versions pre-6.x [require a full cluster restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
 

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "collecting arguments..."
 
-DEFAULT_VERSION="6.2"
+DEFAULT_VERSION="7.5"
 MAJOR_VERSION=${1:-$DEFAULT_VERSION}
 echo "major version: $MAJOR_VERSION"
 
@@ -20,46 +20,11 @@ case "${MAJOR_VERSION}" in
 1.0) docker run -d -p 9200:9200 barnybug/elasticsearch:1.0.0
      MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
     ;;
-1.4) docker run -d -p 9200:9200 barnybug/elasticsearch:1.4.4
-     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
-    ;;
-1.7) docker run -d -p 9200:9200 barnybug/elasticsearch:1.7.2
-     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
-    ;;
-2.0) docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:2.0.2
-     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
-    ;;
-2.1) docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:2.1.2
-     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
-    ;;
-2.2) docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:2.2.2
-     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
-    ;;
-2.3) docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:2.3.5
+1.7) docker run -d -p 9200:9200 barnybug/elasticsearch:1.7.6
      MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
     ;;
 2.4) docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:2.4.6
      MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
-    ;;
-5.0) docker run -d -p 9200:9200 \
-          -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:5.0.2
-     MAPPING_FILE=$(pwd)/test-data/es5_shakespeare_mapping.json
-    ;;
-5.3) docker run -d -p 9200:9200 \
-          -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:5.3.3
-     MAPPING_FILE=$(pwd)/test-data/es5_shakespeare_mapping.json
-    ;;
-5.4) docker run -d -p 9200:9200 \
-          -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:5.4.3
-     MAPPING_FILE=$(pwd)/test-data/es5_shakespeare_mapping.json
-    ;;
-5.5) docker run -d -p 9200:9200 \
-          -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:5.5.3
-     MAPPING_FILE=$(pwd)/test-data/es5_shakespeare_mapping.json
     ;;
 5.6) docker run -d -p 9200:9200 \
           -e "xpack.security.enabled=false" \
@@ -72,28 +37,16 @@ case "${MAJOR_VERSION}" in
           docker.elastic.co/elasticsearch/elasticsearch:6.0.1
      MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
     ;;
-6.1) docker run -d -p 9200:9200 \
-          -e "discovery.type=single-node" \
-          -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:6.1.4
-     MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
-    ;;
-6.2) docker run -d -p 9200:9200 \
-          -e "discovery.type=single-node" \
-          -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:6.2.4
-     MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
-    ;;
 6.8) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:6.8.2
+          docker.elastic.co/elasticsearch/elasticsearch:6.8.6
      MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
      ;;
-7.3) docker run -d -p 9200:9200 \
+7.5) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:7.3.1
+          docker.elastic.co/elasticsearch/elasticsearch:7.5.2
      MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
      SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;


### PR DESCRIPTION
This PR updates the versions of Elasticsearch tested against in CI, per the agreement in CONTRIBUTING.md. It also removes some unnecessary intermediate versions in `setup_local.sh`.