### PR TITLE
FIX: replaces all `ES` with `Elasticsearch` (fixes #202)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ You may notice that this strategy means that `uptasticsearch` is tested for back
 
 When developing on this package, you may want to run Elasticsearch locally to speed up the testing cycle. We've provided some gross bash scripts at the root of this repo to help!
 
-To run the code below, you will need [Docker](https://www.docker.com/). Note that I've passed an argument to `setup_local.sh` indicating the major version of ES I want to run. If you don't do that, this script will just run the most recent major version of Elasticsearch. Look at the source code of `setup_local.sh` for a list of the valid arguments.
+To run the code below, you will need [Docker](https://www.docker.com/). Note that I've passed an argument to `setup_local.sh` indicating the major version of Elasticsearch I want to run. If you don't do that, this script will just run the most recent major version of Elasticsearch. Look at the source code of `setup_local.sh` for a list of the valid arguments.
 
 ```
 # Start up Elasticsearch on localhost:9200 and seed it with data

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,8 @@
 
 ## Features
 
-### Added support for ES7.x
-- [#161](https://github.com/uptake/uptasticsearch/pull/161) Added support for ES7.x. The biggest changes between that major version and 6.x were the removal of `_all` as a way to reference all indices, changing the response format of `hits.total` into an object like `{"hits": {"total": 50}}`, and restricting all indices to have a single type of document. More details can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html.
+### Added support for Elasticsearch 7.x
+- [#161](https://github.com/uptake/uptasticsearch/pull/161) Added support for Elasticsearch 7.x. The biggest changes between that major version and 6.x were the removal of `_all` as a way to reference all indices, changing the response format of `hits.total` into an object like `{"hits": {"total": 50}}`, and restricting all indices to have a single type of document. More details can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html.
 
 # uptasticsearch 0.3.1
 
@@ -26,20 +26,20 @@
 
 ## Features
 
-### Full support for ES6.x
-- [#64](https://github.com/uptake/uptasticsearch/pull/64) added support for ES6.x. The biggest change between that major version and v5.x is that as of ES6.x all requests issued to the ES HTTP API must pass an explicit `Content-Type` header. Previous versions of ES tried to guess the `Content-Type` when none was declared
-- [#66](https://github.com/uptake/uptasticsearch/pull/66) completed support for ES6.x. ES6.x changed the supported strategy for issuing scrolling requests. `uptasticsearch` will now hit the cluster to try to figure out which version of ES it is running, then use the appropriate scrolling strategy.
+### Full support for Elasticsearch 6.x
+- [#64](https://github.com/uptake/uptasticsearch/pull/64) added support for Elasticsearch 6.x. The biggest change between that major version and v5.x is that as of Elasticsearch 6.x all requests issued to the Elasticsearch HTTP API must pass an explicit `Content-Type` header. Previous versions of Elasticsearch tried to guess the `Content-Type` when none was declared
+- [#66](https://github.com/uptake/uptasticsearch/pull/66) completed support for Elasticsearch 6.x. Elasticsearch 6.x changed the supported strategy for issuing scrolling requests. `uptasticsearch` will now hit the cluster to try to figure out which version of Elasticsearch it is running, then use the appropriate scrolling strategy.
 
 ## Bugfixes
 
 ### `get_fields()` when your index has no aliases
-- previously, `get_fields()` broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the `_cat/aliases` endpoint has changed from major version to major version. [#66](https://github.com/uptake/uptasticsearch/pull/66) fixed this for all major versions of ES from 1.0 to 6.2
+- previously, `get_fields()` broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the `_cat/aliases` endpoint has changed from major version to major version. [#66](https://github.com/uptake/uptasticsearch/pull/66) fixed this for all major versions of Elasticsearch from 1.0 to 6.2
 
 ### `get_fields()` when your index has multiple aliases
 - previously, if you had multiple aliases pointing to the same physical index, `get_fields()` would only return one of those. As of [#73](https://github.com/uptake/uptasticsearch/pull/73), mappings for the underlying physical index will now be duplicated once per alias in the table returned by `get_fields()`.
 
-### bad parsing of ES major version
-- as of [#64](https://github.com/uptake/uptasticsearch/pull/64), `uptasticsearch` attempts to query the ES host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in [#66](https://github.com/uptake/uptasticsearch/pull/66). NOTE: this only impacted the dev version of the library on Github.
+### bad parsing of Elasticsearch major version
+- as of [#64](https://github.com/uptake/uptasticsearch/pull/64), `uptasticsearch` attempts to query the Elasticsearch host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in [#66](https://github.com/uptake/uptasticsearch/pull/66). NOTE: this only impacted the dev version of the library on Github.
 
 ### `ignore_scroll_restriction` not being respected
 - In previous versions of `uptasticsearch`, the value passed to `es_search()` for `ignore_scroll_restriction` was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn't getting passed through. [#66](https://github.com/uptake/uptasticsearch/pull/66) instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won't be able to silently get through testing in the future.
@@ -77,7 +77,7 @@
 ## Features
 
 ### Main function
-- `es_search()` executes an ES query and gets a data.table
+- `es_search()` executes an Elasticsearch query and gets a data.table
 
 ### Parse raw JSON into data.table
 - `chomp_aggs()` converts a raw aggs JSON to data.table

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The examples presented here pertain to a fictional Elasticsearch index holding s
 
 ### Example 1: Get a Batch of Documents <a name="example1"></a>
 
-The most common use case for this package will be the case where you have an ES query and want to get a data frame representation of many resulting documents. 
+The most common use case for this package will be the case where you have an Elasticsearch query and want to get a data frame representation of many resulting documents. 
 
 In the example below, we use `uptasticsearch` to look for all survey results in which customers said their satisfaction was "low" or "very low" and mentioned food in their comments.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@ pip install .</code></pre>
 <h3 class="hasAnchor">
 <a href="#example-1-get-a-batch-of-documents" class="anchor"></a>Example 1: Get a Batch of Documents <a name="example1"></a>
 </h3>
-<p>The most common use case for this package will be the case where you have an ES query and want to get a data frame representation of many resulting documents.</p>
+<p>The most common use case for this package will be the case where you have an Elasticsearch query and want to get a data frame representation of many resulting documents.</p>
 <p>In the example below, we use <code>uptasticsearch</code> to look for all survey results in which customers said their satisfaction was “low” or “very low” and mentioned food in their comments.</p>
 <pre><code><a href="https://www.rdocumentation.org/packages/base/topics/library">library(uptasticsearch)
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -124,10 +124,10 @@
 <a href="#features" class="anchor"></a>Features</h2>
 <div id="added-support-for-es7-x" class="section level3">
 <h3 class="hasAnchor">
-<a href="#added-support-for-es7-x" class="anchor"></a>Added support for ES7.x</h3>
+<a href="#added-support-for-es7-x" class="anchor"></a>Added support for Elasticsearch 7.x</h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/161"><a href='https://github.com/uptake/uptasticsearch/issues/161'>#161</a></a> Added support for ES7.x. The biggest changes between that major version and 6.x were the removal of <code>_all</code> as a way to reference all indices, changing the response format of <code>hits.total</code> into an object like <code>{"hits": {"total": 50}}</code>, and restricting all indices to have a single type of document. More details can be found at <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html" class="uri">https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html</a>.</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/161"><a href='https://github.com/uptake/uptasticsearch/issues/161'>#161</a></a> Added support for Elasticsearch 7.x. The biggest changes between that major version and 6.x were the removal of <code>_all</code> as a way to reference all indices, changing the response format of <code>hits.total</code> into an object like <code>{"hits": {"total": 50}}</code>, and restricting all indices to have a single type of document. More details can be found at <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html" class="uri">https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html</a>.</li>
 </ul>
 </div>
 </div>
@@ -166,12 +166,12 @@
 <a href="#features-1" class="anchor"></a>Features</h2>
 <div id="full-support-for-es6-x" class="section level3">
 <h3 class="hasAnchor">
-<a href="#full-support-for-es6-x" class="anchor"></a>Full support for ES6.x</h3>
+<a href="#full-support-for-es6-x" class="anchor"></a>Full support for Elasticsearch 6.x</h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues/64'>#64</a></a> added support for ES6.x. The biggest change between that major version and v5.x is that as of ES6.x all requests issued to the ES HTTP API must pass an explicit <code>Content-Type</code> header. Previous versions of ES tried to guess the <code>Content-Type</code> when none was declared</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues/64'>#64</a></a> added support for Elasticsearch 6.x. The biggest change between that major version and v5.x is that as of Elasticsearch 6.x all requests issued to the Elasticsearch HTTP API must pass an explicit <code>Content-Type</code> header. Previous versions of Elasticsearch tried to guess the <code>Content-Type</code> when none was declared</li>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> completed support for ES6.x. ES6.x changed the supported strategy for issuing scrolling requests. <code>uptasticsearch</code> will now hit the cluster to try to figure out which version of ES it is running, then use the appropriate scrolling strategy.</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> completed support for Elasticsearch 6.x. Elasticsearch 6.x changed the supported strategy for issuing scrolling requests. <code>uptasticsearch</code> will now hit the cluster to try to figure out which version of Elasticsearch it is running, then use the appropriate scrolling strategy.</li>
 </ul>
 </div>
 </div>
@@ -182,7 +182,7 @@
 <h3 class="hasAnchor">
 <a href="#get_fields-when-your-index-has-no-aliases" class="anchor"></a><code>get_fields()</code> when your index has no aliases</h3>
 <ul>
-<li>previously, <code>get_fields()</code> broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the <code>_cat/aliases</code> endpoint has changed from major version to major version. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> fixed this for all major versions of ES from 1.0 to 6.2</li>
+<li>previously, <code>get_fields()</code> broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the <code>_cat/aliases</code> endpoint has changed from major version to major version. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> fixed this for all major versions of Elasticsearch from 1.0 to 6.2</li>
 </ul>
 </div>
 <div id="get_fields-when-your-index-has-multiple-aliases" class="section level3">
@@ -194,9 +194,9 @@
 </div>
 <div id="bad-parsing-of-es-major-version" class="section level3">
 <h3 class="hasAnchor">
-<a href="#bad-parsing-of-es-major-version" class="anchor"></a>bad parsing of ES major version</h3>
+<a href="#bad-parsing-of-es-major-version" class="anchor"></a>bad parsing of Elasticsearch major version</h3>
 <ul>
-<li>as of <a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues/64'>#64</a></a>, <code>uptasticsearch</code> attempts to query the ES host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a>. NOTE: this only impacted the dev version of the library on Github.</li>
+<li>as of <a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues/64'>#64</a></a>, <code>uptasticsearch</code> attempts to query the Elasticsearch host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a>. NOTE: this only impacted the dev version of the library on Github.</li>
 </ul>
 </div>
 <div id="ignore_scroll_restriction-not-being-respected" class="section level3">
@@ -289,7 +289,7 @@
 <a href="#main-function" class="anchor"></a>Main function</h3>
 <ul>
 <li>
-<code>es_search()</code> executes an ES query and gets a data.table</li>
+<code>es_search()</code> executes an Elasticsearch query and gets a data.table</li>
 </ul>
 </div>
 <div id="parse-raw-json-into-data-table" class="section level3">

--- a/docs/reference/es_search.html
+++ b/docs/reference/es_search.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Execute an ES query and get a data.table — es_search() • uptasticsearch</title>
+<title>Execute an Elasticsearch query and get a data.table — es_search() • uptasticsearch</title>
 
 <!-- jquery -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -30,7 +30,7 @@
 
 
 
-<meta property="og:title" content="Execute an ES query and get a data.table — es_search()" />
+<meta property="og:title" content="Execute an Elasticsearch query and get a data.table — es_search()" />
 
 <meta property="og:description" content="Given a query and some optional parameters, es_search() gets results
              from HTTP requests to Elasticsearch and returns a data.table
@@ -116,7 +116,7 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Execute an ES query and get a data.table</h1>
+    <h1>Execute an Elasticsearch query and get a data.table</h1>
     <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/es_search.R'><code>R/es_search.R</code></a></small>
     <div class="hidden name"><code>es_search.Rd</code></div>
     </div>
@@ -213,7 +213,7 @@ and write to a temporary directory under whatever path you provide.</p></td>
     
     <h2 class="hasAnchor" id="references"><a class="anchor" href="#references"></a>References</h2>
 
-    <p><a href='https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html'>ES 6 scrolling strategy</a></p>
+    <p><a href='https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html'>Elasticsearch 6 scrolling strategy</a></p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -134,7 +134,7 @@
         <td>
           <p><code><a href="es_search.html">es_search()</a></code> </p>
         </td>
-        <td><p>Execute an ES query and get a data.table</p></td>
+        <td><p>Execute an Elasticsearch query and get a data.table</p></td>
       </tr>
     </tbody><tbody>
       <tr>

--- a/py-pkg/uptasticsearch/fetch_all.py
+++ b/py-pkg/uptasticsearch/fetch_all.py
@@ -1,4 +1,4 @@
-"""Functions for Pulling data from ES and unpacking into a table
+"""Functions for Pulling data from Elasticsearch and unpacking into a table
 """
 
 import pandas as pd
@@ -14,7 +14,7 @@ def es_search(es_host, es_index, query_body="{}", size=10000, max_hits=None,
 
     Args:
         es_host (string): a url of the elasticsearch cluster e.g. http://localhost:9200
-        es_index (string): the name of the ES index
+        es_index (string): the name of the Elasticsearch index
         query_body (json): json query
         size (int): the number of hits per page. Note: the size will not affect max_hits, but it will affect the time to return the max_hits.
         max_hits (int, None): the total number of hits to allow. If None, no limit

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -1,5 +1,5 @@
 
-#' @title Execute an ES query and get a data.table
+#' @title Execute an Elasticsearch query and get a data.table
 #' @name es_search
 #' @description Given a query and some optional parameters, \code{es_search} gets results
 #'              from HTTP requests to Elasticsearch and returns a data.table
@@ -73,7 +73,7 @@
 #'                       , es_index = 'ticket_sales'
 #'                       , query_body = query_body)
 #' }
-#' @references \href{https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html}{ES 6 scrolling strategy}
+#' @references \href{https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html}{Elasticsearch 6 scrolling strategy}
 es_search <- function(es_host
                       , es_index
                       , size = 10000
@@ -256,7 +256,7 @@ es_search <- function(es_host
 
     # If max_hits < size, we should just request exactly that many hits
     # requesting more hits than you get is not costless:
-    # - ES allocates a temporary data structure of size <size>
+    # - Elasticsearch allocates a temporary data structure of size <size>
     # - you end up transmitting more data over the wire than the user wants
     if (max_hits < size) {
         msg <- paste0(sprintf("You requested a maximum of %s hits", max_hits),
@@ -427,7 +427,7 @@ es_search <- function(es_host
 # [params] file_name Full path to a .json file with a query result
 # [params] keep_nested_data_cols Boolean flag indicating whether or not to
 #          preserver columns that could not be flattened in the result
-#          data.table (i.e. live as arrays with duplicate keys in the result from ES)
+#          data.table (i.e. live as arrays with duplicate keys in the result from Elasticsearch)
 .read_and_parse_tempfile <- function(file_name, keep_nested_data_cols){
 
     # NOTE: namespacing uptasticsearch here to prevent against weirdness
@@ -474,8 +474,8 @@ es_search <- function(es_host
                             , hits_to_pull
 ){
 
-    # Note that the old scrolling strategy was deprecated in ES5.x and
-    # officially dropped in ES6.x. Need to grab the correct method here
+    # Note that the old scrolling strategy was deprecated in Elasticsearch 5.x and
+    # officially dropped in Elasticsearch 6.x. Need to grab the correct method here
     major_version <- .get_es_version(es_host)
     scrolling_request <- switch(
         major_version
@@ -524,7 +524,7 @@ es_search <- function(es_host
 }
 
 
-# [title] Make a scroll request with the strategy supported by ES 5.x and later
+# [title] Make a scroll request with the strategy supported by Elasticsearch 5.x and later
 # [name] .new_scroll_request
 # [description] Make a scrolling request and return the result
 # [references] https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html
@@ -544,7 +544,7 @@ es_search <- function(es_host
     return(result)
 }
 
-# [title] Make a scroll request with the strategy supported by ES 1.x and ES 2.x
+# [title] Make a scroll request with the strategy supported by Elasticsearch 1.x and Elasticsearch 2.x
 # [name] .legacy_scroll_request
 # [description] Make a scrolling request and return the result
 #' @importFrom httr add_headers RETRY
@@ -618,7 +618,7 @@ es_search <- function(es_host
 }
 
 
-# [title] Get ES cluster version
+# [title] Get Elasticsearch cluster version
 # [name] .get_es_version
 # [description] Hit the cluster and figure out the major
 #               version of Elasticsearch.

--- a/r-pkg/R/get_fields.R
+++ b/r-pkg/R/get_fields.R
@@ -94,7 +94,7 @@ get_fields <- function(es_host
 
     ######################### flatten the result ##############################
     if (as.integer(major_version) > 6){
-        # As of ES7, indices cannot contain multiple types so the concept of
+        # As of Elasticsearch 7, indices cannot contain multiple types so the concept of
         # a "type" in a mapping is irrelevant. Maintaining the field here
         # for backwards compatibility of this function.
         mappingDT <- data.table::rbindlist(
@@ -211,8 +211,8 @@ get_fields <- function(es_host
     resultContent <- httr::content(result, as = 'text')
 
     # NOTES:
-    # - with ES1.7.2., this returns an empty array "[]"
-    # - with ES6, this results in an empty string instead of a NULL
+    # - with Elasticsearch 1.7.2., this returns an empty array "[]"
+    # - with Elasticsearch 6, this results in an empty string instead of a NULL
     if (is.null(resultContent) || identical(resultContent, "") || identical(resultContent, "[]")) {
         # there are no aliases in this Elasticsearch cluster
         return(invisible(NULL))
@@ -232,7 +232,7 @@ get_fields <- function(es_host
 
 
 # [title] Process the string returned by the GET alias API into a data.table
-# [description] Older version of ES (pre-5.x) had a slightly different return
+# [description] Older version of Elasticsearch (pre-5.x) had a slightly different return
 #               format for aliases. This handles those
 # [alias_string] A string returned by the alias API with index and alias name
 #' @importFrom data.table as.data.table
@@ -249,7 +249,7 @@ get_fields <- function(es_host
 }
 
 # [title] Process the string returned by the GET alias API into a data.table
-# [description] This only works for ES5 and up
+# [description] This only works for Elasticsearch 5 and up
 # [alias_string] A string returned by the alias API with index and alias name
 #' @importFrom data.table data.table
 #' @importFrom utils read.table

--- a/r-pkg/man/es_search.Rd
+++ b/r-pkg/man/es_search.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/es_search.R
 \name{es_search}
 \alias{es_search}
-\title{Execute an ES query and get a data.table}
+\title{Execute an Elasticsearch query and get a data.table}
 \usage{
 es_search(es_host, es_index, size = 10000, query_body = "{}",
   scroll = "5m", max_hits = Inf,
@@ -99,5 +99,5 @@ resultDT <- es_search(es_host = "http://es.custdb.mycompany.com:9200"
 }
 }
 \references{
-\href{https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html}{ES 6 scrolling strategy}
+\href{https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html}{Elasticsearch 6 scrolling strategy}
 }

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -174,7 +174,7 @@ futile.logger::flog.threshold(0)
     })
 
     # We have tests on static empty results, but this test will catch
-    # changes across versions in the way ES actually responds to aggs results that
+    # changes across versions in the way Elasticsearch actually responds to aggs results that
     # return nothing
     test_that("es_search correctly handles empty bucketed aggregation result", {
         testthat::skip_on_cran()
@@ -199,8 +199,8 @@ futile.logger::flog.threshold(0)
         expect_true(assertthat::is.string(ver), info = paste0("returned version: ", ver))
 
         # Decided to check that it's coercible to an integer instead of
-        # hard-coding known ES versions so this test won't require
-        # attention or break builds if/when ES7 or whatever the next major verison
+        # hard-coding known Elasticsearch versions so this test won't require
+        # attention or break builds if/when Elasticsearch 7 or whatever the next major verison
         # is comes out
         expect_true(!is.na(as.integer(ver)), info = paste0("returned version: ", ver))
     })
@@ -233,7 +233,7 @@ futile.logger::flog.threshold(0)
         expect_null(result)
     })
 
-    test_that("get_fields works on an actual running ES cluster with no aliases", {
+    test_that("get_fields works on an actual running Elasticsearch cluster with no aliases", {
         testthat::skip_on_cran()
 
         fieldDT <- get_fields(
@@ -335,7 +335,7 @@ futile.logger::flog.threshold(0)
 
         # get_fields should work for "_all" indices
         # NOTE: this was deprecated in Elasticsearch 6 and removed in
-        #       ES7, but we use it here so that old uptasticsearch code
+        #       Elasticsearch 7, but we use it here so that old uptasticsearch code
         #       continues to work
         fieldDT <- get_fields(
             es_host = "http://127.0.0.1:9200"


### PR DESCRIPTION
Since the comment syntax is very consistent, it was straightforward to do a sed replace with

```for file in `grep -Rl "\WES\W" *`; do sed -i "s@\([^a-zA-Z0-9]\)ES\([^a-zA-Z0-9]\)@\1Elasticsearch\2@g" $file; done```

Note that the above does not replace instances of the form `"ES6.x"` for example. Would be happy to add that on to this PR if desired.