### PR TITLE
[docs] fixed language annotations on code blocks in markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ When developing on this package, you may want to run Elasticsearch locally to sp
 
 To run the code below, you will need [Docker](https://www.docker.com/). Note that I've passed an argument to `setup_local.sh` indicating the major version of Elasticsearch I want to run. If you don't do that, this script will just run the most recent major version of Elasticsearch. Look at the source code of `setup_local.sh` for a list of the valid arguments.
 
-```
+```shell
 # Start up Elasticsearch on localhost:9200 and seed it with data
 ./setup_local.sh 5.5
 
@@ -149,7 +149,7 @@ https://uptake.github.io/uptasticsearch/
 
 This documentation needs to be periodically, manually updated. To generate the new files for an "update the site" PR, just run the following:
 
-```
+```shell
 make gh_pages
 ```
 
@@ -159,7 +159,7 @@ Note that for now, the R project is more mature and that is the only docs we hos
 
 Build the package tarball by running the following
 
-```
+```shell
 make build_r
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The core functionality of this package is the `es_search()` function. This retur
 
 Releases of this package can be installed from CRAN:
 
-``` r
+```r
 install.packages(
   'uptasticsearch'
   , repos = "http://cran.rstudio.com"
@@ -40,7 +40,7 @@ install.packages(
 
 To use the development version of the package, which has the newest changes, you can install directly from GitHub
 
-``` r
+```r
 devtools::install_github(
   "uptake/uptasticsearch"
   , subdir = "r-pkg"
@@ -53,7 +53,7 @@ devtools::install_github(
 
 This package is not currently available on PyPi. To build the development version from source, clone this repo, then :
 
-``` shell
+```shell
 cd py-pkg
 pip install .
 ```
@@ -68,7 +68,7 @@ The most common use case for this package will be the case where you have an Ela
 
 In the example below, we use `uptasticsearch` to look for all survey results in which customers said their satisfaction was "low" or "very low" and mentioned food in their comments.
 
-``` r
+```r
 library(uptasticsearch)
 
 # Build your query in an R string
@@ -116,7 +116,7 @@ Elasticsearch ships with a rich set of aggregations for creating summarized view
 
 In the example below, we use `uptasticsearch` to create daily timeseries of summary statistics like total revenue and average payment amount.
 
-``` r
+```r
 library(uptasticsearch)
 
 # Build your query in an R string


### PR DESCRIPTION
Some of our inline code blocks don't have language annotations, and others are incorrect (with a space between the final backtick and language).

Here are some docs on how this works, for anyone who's interested. https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#code-and-syntax-highlighting