### PR TITLE
[ci] updated Elasticsearch versions in CI and docs

### DIFF
--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -50,7 +50,7 @@ case "$ES_VERSION" in
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
-    "6.8.6")
+    "6.8.8")
       export MAPPING_FILE=${ES6_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
@@ -91,6 +91,13 @@ case "$ES_VERSION" in
       ;;
 
     "7.5.2")
+      export MAPPING_FILE=${ES7_MAPPING_FILE};
+      export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
+      # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data
+      export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
+      ;;
+
+    "7.6.2")
       export MAPPING_FILE=${ES7_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
       # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       warnings_are_errors: true
       cache: packages
       env:
-        - ES_VERSION=6.8.6
+        - ES_VERSION=6.8.8
         - TASK=rpkg
     - language: r
       warnings_are_errors: true
@@ -89,6 +89,12 @@ matrix:
       cache: packages
       env:
         - ES_VERSION=7.5.2
+        - TASK=rpkg
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.6.2
         - TASK=rpkg
       after_success:
         - .ci/report_to_covr.sh
@@ -123,7 +129,7 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - ES_VERSION=6.8.6
+        - ES_VERSION=6.8.8
         - TASK=pypkg
     - language: python
       python: 3.5
@@ -154,4 +160,9 @@ matrix:
       python: 3.5
       env:
         - ES_VERSION=7.5.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=7.6.2
         - TASK=pypkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,20 +88,21 @@ The set of Elasticsearch versions this project tests against changes regularly a
 
 > `uptasticsearch` may be tested against specific additional intermediate versions if bugs are found in the interaction between `uptasticsearch` and those versions
 
-So, for example, as of January 2020 that meant we tested against:
+So, for example, as of April 2020 that meant we tested against:
 
 * 1.0.0
 * 1.7.6
 * 2.4.6
 * 5.6.16
 * 6.0.1
-* 6.8.6
+* 6.8.8
 * 7.0.1
 * 7.1.1
 * 7.2.1
 * 7.3.2
 * 7.4.2
 * 7.5.2
+* 7.6.2
 
 You may notice that this strategy means that `uptasticsearch` is tested for backwards compatibility with Elasticsearch versions which have already reached [End-of-Life](https://www.elastic.co/support/eol). For example, support for Elasticsearch 1.7.x officially ended in January 2017. We test these old versions because we know of users whose companies still run those versions, and for whom Elasticsearch upgrades are prohibitively expensive. In general, upgrades across major versions pre-6.x [require a full cluster restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
 

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "collecting arguments..."
 
-DEFAULT_VERSION="7.5"
+DEFAULT_VERSION="7.6"
 MAJOR_VERSION=${1:-$DEFAULT_VERSION}
 echo "major version: $MAJOR_VERSION"
 
@@ -40,13 +40,13 @@ case "${MAJOR_VERSION}" in
 6.8) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:6.8.6
+          docker.elastic.co/elasticsearch/elasticsearch:6.8.8
      MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
      ;;
-7.5) docker run -d -p 9200:9200 \
+7.6) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+          docker.elastic.co/elasticsearch/elasticsearch:7.6.2
      MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
      SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;


### PR DESCRIPTION
it's been two months since we updated versions we test against (#204 ). This PR does that again. Just two changes in this one:

* `6.8.6` --> `6.8.8`
* `+ 7.6.2` (previous latest was `7.5.2`)

This is the page I use to find what versions have been released: https://www.elastic.co/downloads/past-releases#elasticsearch