### PR TITLE
[ci] remove devtools and fix small docs stuff

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -11,7 +11,7 @@ export JAVA_APT_PKG="oracle-java8-set-default"
 # install these testing packages we need
 if [[ "$TASK" == "rpkg" ]];
 then
-  Rscript -e "install.packages(c('data.table', 'futile.logger', 'knitr', 'lintr', 'testthat', 'rmarkdown', 'uuid'), repos = 'http://cran.rstudio.com')"
+  Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'http://cran.rstudio.com')"
   cp test-data/* r-pkg/inst/testdata/
 fi
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -11,7 +11,7 @@ export JAVA_APT_PKG="oracle-java8-set-default"
 # install these testing packages we need
 if [[ "$TASK" == "rpkg" ]];
 then
-  Rscript -e "install.packages(c('data.table', 'devtools', 'futile.logger', 'knitr', 'lintr', 'testthat', 'rmarkdown', 'uuid'), repos = 'http://cran.rstudio.com')"
+  Rscript -e "install.packages(c('data.table', 'futile.logger', 'knitr', 'lintr', 'testthat', 'rmarkdown', 'uuid'), repos = 'http://cran.rstudio.com')"
   cp test-data/* r-pkg/inst/testdata/
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ py-pkg/docs/_build
 # at the repo root, should protect against
 # people committing files in r-pkg
 r-pkg/docs/
+
+# backup files from command-line tools
+*.bak

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ make coverage_r
 
 ### Checking code style
 
-The R package's code style is tested with `{lintr}`. To check the code locally, r un the following
+The R package's code style is tested with `{lintr}`. To check the code locally, run the following
 
 ```shell
 Rscript .ci/lint_r_code.R $(pwd)
@@ -157,7 +157,7 @@ Add a section for this release to `cran-comments.md`. This file holds details of
 
 Change the `Version:` field in `DESCRIPTION` to the official version you want on CRAN (should not have a trailing `.9000`).
 
-This project uses Github Pages to host a documentation site:
+This project uses GitHub Pages to host a documentation site:
 
 https://uptake.github.io/uptasticsearch/
 
@@ -167,7 +167,7 @@ This documentation needs to be periodically, manually updated. To generate the n
 make gh_pages
 ```
 
-Note that for now, the R project is more mature and that is the only docs we host on the Github Pages site.
+Note that for now, the R project is more mature and that is the only docs we host on the GitHub Pages site.
 
 **Submit to CRAN**
 
@@ -191,7 +191,7 @@ Once the submission is accepted, great! Update `cran-comments.md` and merge the 
 
 **Create a Release on GitHub**
 
-We use [the releases section](https://github.com/uptake/uptasticsearch/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes::install_github()` for old versions.
+We use [the releases section](https://github.com/uptake/uptasticsearch/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes:install_github()` for old versions.
 
 Navigate to https://github.com/uptake/uptasticsearch/releases/new. Click the dropdown in the "target" section, then click "recent commits". Choose the latest commit for the release PR you just merged. This will automatically create a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on that commit and tell Github which revision to build when people ask for a given release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ Once the submission is accepted, great! Update `cran-comments.md` and merge the 
 
 **Create a Release on GitHub**
 
-We use [the releases section](https://github.com/uptake/uptasticsearch/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes:install_github()` for old versions.
+We use [the releases section](https://github.com/uptake/uptasticsearch/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes::install_github()` for old versions.
 
 Navigate to https://github.com/uptake/uptasticsearch/releases/new. Click the dropdown in the "target" section, then click "recent commits". Choose the latest commit for the release PR you just merged. This will automatically create a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on that commit and tell Github which revision to build when people ask for a given release.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-
-
-.PHONY: docs_r r-pkg
+.PHONY: build_r coverage_r docs_r install_r test_r build_py docs_py install_py test_py gh_pages
 
 #####
 # R #
@@ -19,7 +17,7 @@ coverage_r: build_r
 	open coverage.html
 
 docs_r: build_r
-	Rscript -e "devtools::document('r-pkg/')"
+	Rscript -e "roxygen2::roxygenize('r-pkg/')"
 	Rscript -e "pkgdown::build_site('r-pkg/')"
 
 install_r: build_r

--- a/r-pkg/tests/testthat.R
+++ b/r-pkg/tests/testthat.R
@@ -1,7 +1,5 @@
 # Note that you would never run this file directly. This is used by tools::testInstallPackages()
 # and other packages like covr.
-# To actually run the tests, you need to set the working directory then run
-# devtools::test('r-pkg/uptasticsearch')
 
 # This line ensures that R CMD check can run tests.
 # See https://github.com/hadley/testthat/issues/144


### PR DESCRIPTION
I'd like to propose removing `devtools` from this project. We're installing it in CI (which is expensive because it has a lot of dependencies) but I don't think we're actually using it!

We have it in our docs for `install_github()`, but that has since [moved to `remotes`](https://cran.r-project.org/web/packages/remotes/readme/README.html).