### PR TITLE
[docs] fix broken links in pkgdown

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>License • uptasticsearch</title>
+<title>Page not found (404) • uptasticsearch</title>
 
 
 <!-- jquery -->
@@ -39,7 +39,7 @@
 
 
 
-<meta property="og:title" content="License" />
+<meta property="og:title" content="Page not found (404)" />
 
 
 
@@ -122,13 +122,10 @@
 <div class="row">
   <div class="contents col-md-9">
     <div class="page-header">
-      <h1>License</h1>
+      <h1>Page not found (404)</h1>
     </div>
 
-<pre>YEAR: 2017
-COPYRIGHT HOLDER: Uptake Technologies Inc.
-ORGANIZATION: Uptake Technologies Inc.
-</pre>
+Content not found. Please use links in the navbar.
 
   </div>
 

--- a/docs/articles/FAQ.html
+++ b/docs/articles/FAQ.html
@@ -6,18 +6,19 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Frequently Asked Questions • uptasticsearch</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
+<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script><!-- bootstrap-toc --><link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script><!-- headroom.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
 <script src="../pkgdown.js"></script><meta property="og:title" content="Frequently Asked Questions">
-<meta property="og:description" content="">
-<meta name="twitter:card" content="summary">
+<meta property="og:description" content="uptasticsearch">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
 </head>
-<body>
+<body data-spy="scroll" data-target="#toc">
     <div class="container template-article">
       <header><div class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
@@ -30,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -38,7 +39,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -63,8 +64,8 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -77,15 +78,16 @@
 <!--/.navbar -->
 
       
+
       </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
-      <h1>Frequently Asked Questions</h1>
+      <h1 data-toc-skip>Frequently Asked Questions</h1>
                         <h4 class="author">Stephanie Kirmer</h4>
             
-            <h4 class="date">2019-09-09</h4>
+            <h4 class="date">2020-05-11</h4>
       
-      <small class="dont-index">Source: <a href="https://github.com/uptake/uptasticsearch/blob/master/../vignettes/FAQ.Rmd"><code>../vignettes/FAQ.Rmd</code></a></small>
+      <small class="dont-index">Source: <a href="https://github.com/uptake/uptasticsearch/tree/master/r-pkg/../vignettes/FAQ.Rmd"><code>../vignettes/FAQ.Rmd</code></a></small>
       <div class="hidden name"><code>FAQ.Rmd</code></div>
 
     </div>
@@ -144,24 +146,14 @@
 </div>
   </div>
 
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-        <div id="tocnav">
-      <h2 class="hasAnchor">
-<a href="#tocnav" class="anchor"></a>Contents</h2>
-      <ul class="nav nav-pills nav-stacked">
-<li><a href="#introduction">Introduction</a></li>
-      <li>
-<a href="#questions">Questions</a><ul class="nav nav-pills nav-stacked">
-<li><a href="#query-syntax-problems">Query Syntax Problems</a></li>
-      <li><a href="#query-returns-no-results">Query Returns No Results</a></li>
-      </ul>
-</li>
-      <li><a href="#contribute-to-this-guide">Contribute to this Guide!</a></li>
-      </ul>
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+
+        <nav id="toc" data-toggle="toc"><h2 data-toc-skip>Contents</h2>
+    </nav>
 </div>
-      </div>
 
 </div>
+
 
 
       <footer><div class="copyright">
@@ -169,12 +161,14 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
 </div>
 
   
+
 
   </body>
 </html>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -8,21 +8,29 @@
 
 <title>Articles • uptasticsearch</title>
 
-<!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<!-- jquery -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+<!-- Bootstrap -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,7 +38,9 @@
 
 
 
+
 <meta property="og:title" content="Articles" />
+
 
 
 
@@ -44,9 +54,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-article-index">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -60,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -68,7 +79,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -91,11 +102,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -106,6 +116,7 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
@@ -118,12 +129,14 @@
       <h3>All vignettes</h3>
       <p class="section-desc"></p>
 
-      <ul>
-        <li><a href="FAQ.html">Frequently Asked Questions</a></li>
-      </ul>
+      <dl>
+        <dt><a href="FAQ.html">Frequently Asked Questions</a></dt>
+        <dd></dt>
+      </dl>
     </div>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -131,13 +144,16 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -8,21 +8,29 @@
 
 <title>Authors • uptasticsearch</title>
 
-<!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<!-- jquery -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+<!-- Bootstrap -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="bootstrap-toc.css">
+<script src="bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="pkgdown.css" rel="stylesheet">
@@ -30,7 +38,9 @@
 
 
 
+
 <meta property="og:title" content="Authors" />
+
 
 
 
@@ -44,9 +54,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-authors">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -60,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -68,7 +79,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -91,11 +102,10 @@
   <a href="news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -106,6 +116,7 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
@@ -150,19 +161,23 @@
 </div>
 
 
+
       <footer>
       <div class="copyright">
   <p>Developed by James Lamb, Nick Paras, Austin Dickey.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/bootstrap-toc.css
+++ b/docs/bootstrap-toc.css
@@ -1,0 +1,60 @@
+/*!
+ * Bootstrap Table of Contents v0.4.1 (http://afeld.github.io/bootstrap-toc/)
+ * Copyright 2015 Aidan Feldman
+ * Licensed under MIT (https://github.com/afeld/bootstrap-toc/blob/gh-pages/LICENSE.md) */
+
+/* modified from https://github.com/twbs/bootstrap/blob/94b4076dd2efba9af71f0b18d4ee4b163aa9e0dd/docs/assets/css/src/docs.css#L548-L601 */
+
+/* All levels of nav */
+nav[data-toggle='toc'] .nav > li > a {
+  display: block;
+  padding: 4px 20px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #767676;
+}
+nav[data-toggle='toc'] .nav > li > a:hover,
+nav[data-toggle='toc'] .nav > li > a:focus {
+  padding-left: 19px;
+  color: #563d7c;
+  text-decoration: none;
+  background-color: transparent;
+  border-left: 1px solid #563d7c;
+}
+nav[data-toggle='toc'] .nav > .active > a,
+nav[data-toggle='toc'] .nav > .active:hover > a,
+nav[data-toggle='toc'] .nav > .active:focus > a {
+  padding-left: 18px;
+  font-weight: bold;
+  color: #563d7c;
+  background-color: transparent;
+  border-left: 2px solid #563d7c;
+}
+
+/* Nav: second level (shown on .active) */
+nav[data-toggle='toc'] .nav .nav {
+  display: none; /* Hide by default, but at >768px, show it */
+  padding-bottom: 10px;
+}
+nav[data-toggle='toc'] .nav .nav > li > a {
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 30px;
+  font-size: 12px;
+  font-weight: normal;
+}
+nav[data-toggle='toc'] .nav .nav > li > a:hover,
+nav[data-toggle='toc'] .nav .nav > li > a:focus {
+  padding-left: 29px;
+}
+nav[data-toggle='toc'] .nav .nav > .active > a,
+nav[data-toggle='toc'] .nav .nav > .active:hover > a,
+nav[data-toggle='toc'] .nav .nav > .active:focus > a {
+  padding-left: 28px;
+  font-weight: 500;
+}
+
+/* from https://github.com/twbs/bootstrap/blob/e38f066d8c203c3e032da0ff23cd2d6098ee2dd6/docs/assets/css/src/docs.css#L631-L634 */
+nav[data-toggle='toc'] .nav > .active > ul {
+  display: block;
+}

--- a/docs/bootstrap-toc.js
+++ b/docs/bootstrap-toc.js
@@ -1,0 +1,159 @@
+/*!
+ * Bootstrap Table of Contents v0.4.1 (http://afeld.github.io/bootstrap-toc/)
+ * Copyright 2015 Aidan Feldman
+ * Licensed under MIT (https://github.com/afeld/bootstrap-toc/blob/gh-pages/LICENSE.md) */
+(function() {
+  'use strict';
+
+  window.Toc = {
+    helpers: {
+      // return all matching elements in the set, or their descendants
+      findOrFilter: function($el, selector) {
+        // http://danielnouri.org/notes/2011/03/14/a-jquery-find-that-also-finds-the-root-element/
+        // http://stackoverflow.com/a/12731439/358804
+        var $descendants = $el.find(selector);
+        return $el.filter(selector).add($descendants).filter(':not([data-toc-skip])');
+      },
+
+      generateUniqueIdBase: function(el) {
+        var text = $(el).text();
+        var anchor = text.trim().toLowerCase().replace(/[^A-Za-z0-9]+/g, '-');
+        return anchor || el.tagName.toLowerCase();
+      },
+
+      generateUniqueId: function(el) {
+        var anchorBase = this.generateUniqueIdBase(el);
+        for (var i = 0; ; i++) {
+          var anchor = anchorBase;
+          if (i > 0) {
+            // add suffix
+            anchor += '-' + i;
+          }
+          // check if ID already exists
+          if (!document.getElementById(anchor)) {
+            return anchor;
+          }
+        }
+      },
+
+      generateAnchor: function(el) {
+        if (el.id) {
+          return el.id;
+        } else {
+          var anchor = this.generateUniqueId(el);
+          el.id = anchor;
+          return anchor;
+        }
+      },
+
+      createNavList: function() {
+        return $('<ul class="nav"></ul>');
+      },
+
+      createChildNavList: function($parent) {
+        var $childList = this.createNavList();
+        $parent.append($childList);
+        return $childList;
+      },
+
+      generateNavEl: function(anchor, text) {
+        var $a = $('<a></a>');
+        $a.attr('href', '#' + anchor);
+        $a.text(text);
+        var $li = $('<li></li>');
+        $li.append($a);
+        return $li;
+      },
+
+      generateNavItem: function(headingEl) {
+        var anchor = this.generateAnchor(headingEl);
+        var $heading = $(headingEl);
+        var text = $heading.data('toc-text') || $heading.text();
+        return this.generateNavEl(anchor, text);
+      },
+
+      // Find the first heading level (`<h1>`, then `<h2>`, etc.) that has more than one element. Defaults to 1 (for `<h1>`).
+      getTopLevel: function($scope) {
+        for (var i = 1; i <= 6; i++) {
+          var $headings = this.findOrFilter($scope, 'h' + i);
+          if ($headings.length > 1) {
+            return i;
+          }
+        }
+
+        return 1;
+      },
+
+      // returns the elements for the top level, and the next below it
+      getHeadings: function($scope, topLevel) {
+        var topSelector = 'h' + topLevel;
+
+        var secondaryLevel = topLevel + 1;
+        var secondarySelector = 'h' + secondaryLevel;
+
+        return this.findOrFilter($scope, topSelector + ',' + secondarySelector);
+      },
+
+      getNavLevel: function(el) {
+        return parseInt(el.tagName.charAt(1), 10);
+      },
+
+      populateNav: function($topContext, topLevel, $headings) {
+        var $context = $topContext;
+        var $prevNav;
+
+        var helpers = this;
+        $headings.each(function(i, el) {
+          var $newNav = helpers.generateNavItem(el);
+          var navLevel = helpers.getNavLevel(el);
+
+          // determine the proper $context
+          if (navLevel === topLevel) {
+            // use top level
+            $context = $topContext;
+          } else if ($prevNav && $context === $topContext) {
+            // create a new level of the tree and switch to it
+            $context = helpers.createChildNavList($prevNav);
+          } // else use the current $context
+
+          $context.append($newNav);
+
+          $prevNav = $newNav;
+        });
+      },
+
+      parseOps: function(arg) {
+        var opts;
+        if (arg.jquery) {
+          opts = {
+            $nav: arg
+          };
+        } else {
+          opts = arg;
+        }
+        opts.$scope = opts.$scope || $(document.body);
+        return opts;
+      }
+    },
+
+    // accepts a jQuery object, or an options object
+    init: function(opts) {
+      opts = this.helpers.parseOps(opts);
+
+      // ensure that the data attribute is in place for styling
+      opts.$nav.attr('data-toggle', 'toc');
+
+      var $topContext = this.helpers.createChildNavList(opts.$nav);
+      var topLevel = this.helpers.getTopLevel(opts.$scope);
+      var $headings = this.helpers.getHeadings(opts.$scope, topLevel);
+      this.helpers.populateNav($topContext, topLevel, $headings);
+    }
+  };
+
+  $(function() {
+    $('nav[data-toggle="toc"]').each(function(i, el) {
+      var $nav = $(el);
+      Toc.init($nav);
+    });
+  });
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,26 +5,27 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Get Data Frame Representations of 'Elasticsearch' Results • uptasticsearch</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
-<script src="pkgdown.js"></script><meta property="og:title" content="Get Data Frame Representations of 'Elasticsearch' Results">
+<title>Get Data Frame Representations of Elasticsearch Results • uptasticsearch</title>
+<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script><!-- bootstrap-toc --><link rel="stylesheet" href="bootstrap-toc.css">
+<script src="bootstrap-toc.js"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script><!-- headroom.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
+<script src="pkgdown.js"></script><meta property="og:title" content="Get Data Frame Representations of Elasticsearch Results">
 <meta property="og:description" content="
-    'Elasticsearch' is an open-source, distributed, document-based datastore
+    Elasticsearch is an open-source, distributed, document-based datastore
     (&lt;https://www.elastic.co/products/elasticsearch&gt;).
-    It provides an 'HTTP' 'API' for querying the database and extracting datasets, but that
-    'API' was not designed for common data science workflows like pulling large batches of
+    It provides an HTTP API for querying the database and extracting datasets, but that
+    API was not designed for common data science workflows like pulling large batches of
     records and normalizing those documents into a data frame that can be used as a training
-    dataset for statistical models. 'uptasticsearch' provides an interface for 'Elasticsearch'
+    dataset for statistical models. uptasticsearch provides an interface for Elasticsearch
     that is explicitly designed to make these data science workflows easy and fun.">
-<meta name="twitter:card" content="summary">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
 </head>
-<body>
+<body data-spy="scroll" data-target="#toc">
     <div class="container template-home">
       <header><div class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
@@ -37,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -45,7 +46,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -70,8 +71,8 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -84,6 +85,7 @@
 <!--/.navbar -->
 
       
+
       </header><div class="row">
   <div class="contents col-md-9">
 
@@ -94,7 +96,7 @@
 <div id="introduction" class="section level2">
 <h2 class="hasAnchor">
 <a href="#introduction" class="anchor"></a>Introduction</h2>
-<p><code>uptasticsearch</code> tackles the issue of getting data out of Elasticsearch and into a tabular format in R and Python. It should work for all versions of Elasticsearch from 1.0.0 onwards, but <a href="./CONTRIBUTING.md#travis">is not regularly tested against all of them</a>. If you run into a problem, please <a href="https://github.com/uptake/uptasticsearch/issues">open an issue</a>.</p>
+<p><code>uptasticsearch</code> tackles the issue of getting data out of Elasticsearch and into a tabular format in R and Python. It should work for all versions of Elasticsearch from 1.0.0 onwards, but <a href="https://github.com/uptake/uptasticsearch/blob/master/CONTRIBUTING.md#travis">is not regularly tested against all of them</a>. If you run into a problem, please <a href="https://github.com/uptake/uptasticsearch/issues">open an issue</a>.</p>
 </div>
 </div>
 <div id="table-of-contents" class="section level1">
@@ -117,55 +119,59 @@
 </ul>
 </li>
 </ul>
-<div id="how-it-works" class="section level2">
+<div id="how-it-works-" class="section level2">
 <h2 class="hasAnchor">
-<a href="#how-it-works" class="anchor"></a>How it Works <a name="howitworks"></a>
+<a href="#how-it-works-" class="anchor"></a>How it Works <a name="howitworks"></a>
 </h2>
-<p>The core functionality of this package is the <code>es_search()</code> function. This returns a <code>data.table</code> containing the parsed result of any given query. Note that this includes <code>aggs</code> queries.</p>
+<p>The core functionality of this package is the <code><a href="reference/es_search.html">es_search()</a></code> function. This returns a <code>data.table</code> containing the parsed result of any given query. Note that this includes <code>aggs</code> queries.</p>
 </div>
-<div id="installation" class="section level2">
+<div id="installation-" class="section level2">
 <h2 class="hasAnchor">
-<a href="#installation" class="anchor"></a>Installation <a name="installation"></a>
+<a href="#installation-" class="anchor"></a>Installation <a name="installation"></a>
 </h2>
-<div id="r" class="section level3">
+<div id="r-" class="section level3">
 <h3 class="hasAnchor">
-<a href="#r" class="anchor"></a>R <a name="rinstallation"></a>
+<a href="#r-" class="anchor"></a>R <a name="rinstallation"></a>
 </h3>
+<p><img src="https://img.shields.io/badge/lifecycle-maturing-blue.svg" alt="Lifecycle Maturing"></p>
 <p>Releases of this package can be installed from CRAN:</p>
-<pre><code><a href="https://www.rdocumentation.org/packages/utils/topics/install.packages">install.packages(
-  'uptasticsearch'
-  , repos = "http://cran.rstudio.com"
-)</a></code></pre>
+<div class="sourceCode" id="cb1"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(
+  <span class="st">'uptasticsearch'</span>
+  , <span class="kw">repos</span> <span class="kw">=</span> <span class="st">"http://cran.rstudio.com"</span>
+)</pre></div>
+<p>or from <code>conda-forge</code></p>
+<pre class="shell"><code>conda install -c conda-forge r-uptasticsearch</code></pre>
 <p>To use the development version of the package, which has the newest changes, you can install directly from GitHub</p>
-<pre><code><a href="https://www.rdocumentation.org/packages/devtools/topics/reexports">devtools::install_github(
-  "uptake/uptasticsearch"
-  , subdir = "r-pkg"
-)</a></code></pre>
+<div class="sourceCode" id="cb3"><pre class="r"><span class="kw pkg">remotes</span><span class="kw ns">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span>(
+  <span class="st">"uptake/uptasticsearch"</span>
+  , <span class="kw">subdir</span> <span class="kw">=</span> <span class="st">"r-pkg"</span>
+)</pre></div>
 </div>
-<div id="python" class="section level3">
+<div id="python-" class="section level3">
 <h3 class="hasAnchor">
-<a href="#python" class="anchor"></a>Python <a name="pythoninstallation"></a>
+<a href="#python-" class="anchor"></a>Python <a name="pythoninstallation"></a>
 </h3>
+<p><img src="https://img.shields.io/badge/lifecycle-dormant-orange.svg" alt="Lifecycle Dormant"></p>
 <p>This package is not currently available on PyPi. To build the development version from source, clone this repo, then :</p>
-<pre><code>cd py-pkg
+<pre class="shell"><code>cd py-pkg
 pip install .</code></pre>
 </div>
 </div>
-<div id="usage-examples" class="section level2">
+<div id="usage-examples-" class="section level2">
 <h2 class="hasAnchor">
-<a href="#usage-examples" class="anchor"></a>Usage Examples <a name="examples"></a>
+<a href="#usage-examples-" class="anchor"></a>Usage Examples <a name="examples"></a>
 </h2>
 <p>The examples presented here pertain to a fictional Elasticsearch index holding some information on a movie theater business.</p>
-<div id="example-1-get-a-batch-of-documents" class="section level3">
+<div id="example-1-get-a-batch-of-documents-" class="section level3">
 <h3 class="hasAnchor">
-<a href="#example-1-get-a-batch-of-documents" class="anchor"></a>Example 1: Get a Batch of Documents <a name="example1"></a>
+<a href="#example-1-get-a-batch-of-documents-" class="anchor"></a>Example 1: Get a Batch of Documents <a name="example1"></a>
 </h3>
 <p>The most common use case for this package will be the case where you have an Elasticsearch query and want to get a data frame representation of many resulting documents.</p>
 <p>In the example below, we use <code>uptasticsearch</code> to look for all survey results in which customers said their satisfaction was “low” or “very low” and mentioned food in their comments.</p>
-<pre><code><a href="https://www.rdocumentation.org/packages/base/topics/library">library(uptasticsearch)
+<div class="sourceCode" id="cb5"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">uptasticsearch</span>)
 
-# Build your query in an R string
-qbody &lt;- '{
+<span class="co"># Build your query in an R string</span>
+<span class="no">qbody</span> <span class="kw">&lt;-</span> <span class="st">'{
   "query": {
     "filtered": {
       "filter": {
@@ -191,27 +197,27 @@ qbody &lt;- '{
       }
     }
   }
-}'
+}'</span>
 
-# Execute the query, parse into a data.table
-commentDT &lt;- es_search(
-    es_host = 'http://mydb.mycompany.com:9200'
-    , es_index = "survey_results"
-    , query_body = qbody
-    , scroll = "1m"
-    , n_cores = 4
-)</a></code></pre>
+<span class="co"># Execute the query, parse into a data.table</span>
+<span class="no">commentDT</span> <span class="kw">&lt;-</span> <span class="fu"><a href="reference/es_search.html">es_search</a></span>(
+    <span class="kw">es_host</span> <span class="kw">=</span> <span class="st">'http://mydb.mycompany.com:9200'</span>
+    , <span class="kw">es_index</span> <span class="kw">=</span> <span class="st">"survey_results"</span>
+    , <span class="kw">query_body</span> <span class="kw">=</span> <span class="no">qbody</span>
+    , <span class="kw">scroll</span> <span class="kw">=</span> <span class="st">"1m"</span>
+    , <span class="kw">n_cores</span> <span class="kw">=</span> <span class="fl">4</span>
+)</pre></div>
 </div>
-<div id="example-2-aggregation-results" class="section level3">
+<div id="example-2-aggregation-results-" class="section level3">
 <h3 class="hasAnchor">
-<a href="#example-2-aggregation-results" class="anchor"></a>Example 2: Aggregation Results <a name="example2"></a>
+<a href="#example-2-aggregation-results-" class="anchor"></a>Example 2: Aggregation Results <a name="example2"></a>
 </h3>
 <p>Elasticsearch ships with a rich set of aggregations for creating summarized views of your data. <code>uptasticsearch</code> has built-in support for these aggregations.</p>
 <p>In the example below, we use <code>uptasticsearch</code> to create daily timeseries of summary statistics like total revenue and average payment amount.</p>
-<pre><code><a href="https://www.rdocumentation.org/packages/base/topics/library">library(uptasticsearch)
+<div class="sourceCode" id="cb6"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">uptasticsearch</span>)
 
-# Build your query in an R string
-qbody &lt;- '{
+<span class="co"># Build your query in an R string</span>
+<span class="no">qbody</span> <span class="kw">&lt;-</span> <span class="st">'{
   "query": {
     "filtered": {
       "filter": {
@@ -243,17 +249,17 @@ qbody &lt;- '{
     }
   },
   "size": 0
-}'
+}'</span>
 
-# Execute the query, parse result into a data.table
-revenueDT &lt;- es_search(
-    es_host = 'http://mydb.mycompany.com:9200'
-    , es_index = "transactions"
-    , size = 1000
-    , query_body = qbody
-    , n_cores = 1
-)</a></code></pre>
-<p>In the example above, we used the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html">date_histogram</a> and <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html">extended_stats</a> aggregations. <code>es_search()</code> has built-in support for many other aggregations and combinations of aggregations, with more on the way. Please see the table below for the current status of the package. Note that names of the form “agg1 - agg2” refer to the ability to handled aggregations nested inside other aggregations.</p>
+<span class="co"># Execute the query, parse result into a data.table</span>
+<span class="no">revenueDT</span> <span class="kw">&lt;-</span> <span class="fu"><a href="reference/es_search.html">es_search</a></span>(
+    <span class="kw">es_host</span> <span class="kw">=</span> <span class="st">'http://mydb.mycompany.com:9200'</span>
+    , <span class="kw">es_index</span> <span class="kw">=</span> <span class="st">"transactions"</span>
+    , <span class="kw">size</span> <span class="kw">=</span> <span class="fl">1000</span>
+    , <span class="kw">query_body</span> <span class="kw">=</span> <span class="no">qbody</span>
+    , <span class="kw">n_cores</span> <span class="kw">=</span> <span class="fl">1</span>
+)</pre></div>
+<p>In the example above, we used the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html">date_histogram</a> and <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html">extended_stats</a> aggregations. <code><a href="reference/es_search.html">es_search()</a></code> has built-in support for many other aggregations and combinations of aggregations, with more on the way. Please see the table below for the current status of the package. Note that names of the form “agg1 - agg2” refer to the ability to handled aggregations nested inside other aggregations.</p>
 <table class="table">
 <thead><tr class="header">
 <th align="left">Agg type</th>
@@ -419,13 +425,13 @@ revenueDT &lt;- es_search(
 
   </div>
 
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <div class="links">
 <h2>Links</h2>
 <ul class="list-unstyled">
 <li>Download from CRAN at <br><a href="https://cloud.r-project.org/package=uptasticsearch">https://​cloud.r-project.org/​package=uptasticsearch</a>
 </li>
-<li>Browse source code at <br><a href="https://github.com/uptake/uptasticsearch">https://​github.com/​uptake/​uptasticsearch</a>
+<li>Browse source code at <br><a href="https://github.com/uptake/uptasticsearch/">https://​github.com/​uptake/​uptasticsearch/​</a>
 </li>
 <li>Report a bug at <br><a href="https://github.com/uptake/uptasticsearch/issues">https://​github.com/​uptake/​uptasticsearch/​issues</a>
 </li>
@@ -453,6 +459,7 @@ revenueDT &lt;- es_search(
 <h2>Dev status</h2>
 <ul class="list-unstyled">
 <li><a href="https://travis-ci.org/uptake/uptasticsearch"><img src="https://img.shields.io/travis/uptake/uptasticsearch.svg?label=travis&amp;logo=travis&amp;branch=master" alt="Travis Build Status"></a></li>
+<li><a href="https://codecov.io/gh/uptake/uptasticsearch"><img src="https://codecov.io/gh/uptake/uptasticsearch/branch/master/graph/badge.svg" alt="codecov"></a></li>
 <li><a href="https://cran.r-project.org/package=uptasticsearch"><img src="https://www.r-pkg.org/badges/version-last-release/uptasticsearch" alt="CRAN_Status_Badge"></a></li>
 <li><a href="https://cran.r-project.org/package=uptasticsearch"><img src="https://cranlogs.r-pkg.org/badges/grand-total/uptasticsearch" alt="CRAN_Download_Badge"></a></li>
 </ul>
@@ -460,17 +467,20 @@ revenueDT &lt;- es_search(
 </div>
 </div>
 
+
       <footer><div class="copyright">
   <p>Developed by James Lamb, Nick Paras, Austin Dickey.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
 </div>
 
   
+
 
   </body>
 </html>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -8,21 +8,29 @@
 
 <title>Changelog • uptasticsearch</title>
 
-<!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<!-- jquery -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+<!-- Bootstrap -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,7 +38,9 @@
 
 
 
+
 <meta property="og:title" content="Changelog" />
+
 
 
 
@@ -44,9 +54,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-news">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -60,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -68,7 +79,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -91,11 +102,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -106,35 +116,36 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-      <h1>Changelog <small></small></h1>
-      <small>Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
+      <h1 data-toc-skip>Changelog <small></small></h1>
+      <small>Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
-    <div id="uptasticsearch-0-4-0" class="section level1">
-<h1 class="page-header">
-<a href="#uptasticsearch-0-4-0" class="anchor"></a>uptasticsearch 0.4.0<small> Unreleased </small>
+    <div id="uptasticsearch-040" class="section level1">
+<h1 class="page-header" data-toc-text="0.4.0">
+<a href="#uptasticsearch-040" class="anchor"></a>uptasticsearch 0.4.0<small> 2019-09-11 </small>
 </h1>
-<div id="features" class="section level2">
+<div id="features-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features" class="anchor"></a>Features</h2>
-<div id="added-support-for-es7-x" class="section level3">
+<a href="#features-1" class="anchor"></a>Features</h2>
+<div id="added-support-for-elasticsearch-7x" class="section level3">
 <h3 class="hasAnchor">
-<a href="#added-support-for-es7-x" class="anchor"></a>Added support for Elasticsearch 7.x</h3>
+<a href="#added-support-for-elasticsearch-7x" class="anchor"></a>Added support for Elasticsearch 7.x</h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/161"><a href='https://github.com/uptake/uptasticsearch/issues/161'>#161</a></a> Added support for Elasticsearch 7.x. The biggest changes between that major version and 6.x were the removal of <code>_all</code> as a way to reference all indices, changing the response format of <code>hits.total</code> into an object like <code>{"hits": {"total": 50}}</code>, and restricting all indices to have a single type of document. More details can be found at <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html" class="uri">https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html</a>.</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/161"><a href='https://github.com/uptake/uptasticsearch/issues161'>#161</a></a> Added support for Elasticsearch 7.x. The biggest changes between that major version and 6.x were the removal of <code>_all</code> as a way to reference all indices, changing the response format of <code>hits.total</code> into an object like <code>{"hits": {"total": 50}}</code>, and restricting all indices to have a single type of document. More details can be found at <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html" class="uri">https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html</a>.</li>
 </ul>
 </div>
 </div>
 </div>
-    <div id="uptasticsearch-0-3-1" class="section level1">
-<h1 class="page-header">
-<a href="#uptasticsearch-0-3-1" class="anchor"></a>uptasticsearch 0.3.1<small> 2019-01-30 </small>
+    <div id="uptasticsearch-031" class="section level1">
+<h1 class="page-header" data-toc-text="0.3.1">
+<a href="#uptasticsearch-031" class="anchor"></a>uptasticsearch 0.3.1<small> 2019-01-30 </small>
 </h1>
 <div id="bugfixes" class="section level2">
 <h2 class="hasAnchor">
@@ -144,7 +155,7 @@
 <a href="#minor-changes-to-unit-tests-to-comply-with-cran" class="anchor"></a>Minor changes to unit tests to comply with CRAN</h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/136"><a href='https://github.com/uptake/uptasticsearch/issues/136'>#136</a></a> removed calls to <code><a href="https://www.rdocumentation.org/packages/base/topics/showConnections">closeAllConnections()</a></code> in unit tests because they were superfluous and causing problems on certain operating systems in the CRAN check farm.</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/136"><a href='https://github.com/uptake/uptasticsearch/issues136'>#136</a></a> removed calls to <code><a href="https://rdrr.io/r/base/showConnections.html">closeAllConnections()</a></code> in unit tests because they were superfluous and causing problems on certain operating systems in the CRAN check farm.</li>
 </ul>
 </div>
 <div id="changed-strategy-for-removing-duplicate-records" class="section level3">
@@ -152,26 +163,26 @@
 <a href="#changed-strategy-for-removing-duplicate-records" class="anchor"></a>Changed strategy for removing duplicate records</h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/138"><a href='https://github.com/uptake/uptasticsearch/issues/138'>#138</a></a> changed our strategy for deduping records from <code><a href="https://www.rdocumentation.org/packages/base/topics/unique">unique(outDT)</a></code> to <code><a href="https://www.rdocumentation.org/packages/base/topics/unique">unique(outDT, by = "_id")</a></code>. This was prompted by <a href="https://github.com/Rdatatable/data.table/issues/3332">Rdatatable/data.table<a href='https://github.com/uptake/uptasticsearch/issues/3332'>#3332</a></a> (changes in <code>data.table</code> 1.12.0), but it’s actually faster and safer anyway!</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/138"><a href='https://github.com/uptake/uptasticsearch/issues138'>#138</a></a> changed our strategy for deduping records from <code><a href="https://rdrr.io/r/base/unique.html">unique(outDT)</a></code> to <code><a href="https://rdrr.io/r/base/unique.html">unique(outDT, by = "_id")</a></code>. This was prompted by <a href="https://github.com/Rdatatable/data.table/issues/3332">Rdatatable/data.table<a href='https://github.com/uptake/uptasticsearch/issues3332'>#3332</a></a> (changes in <code>data.table</code> 1.12.0), but it’s actually faster and safer anyway!</li>
 </ul>
 </div>
 </div>
 </div>
-    <div id="uptasticsearch-0-3-0" class="section level1">
-<h1 class="page-header">
-<a href="#uptasticsearch-0-3-0" class="anchor"></a>uptasticsearch 0.3.0<small> 2018-06-19 </small>
+    <div id="uptasticsearch-030" class="section level1">
+<h1 class="page-header" data-toc-text="0.3.0">
+<a href="#uptasticsearch-030" class="anchor"></a>uptasticsearch 0.3.0<small> 2018-06-19 </small>
 </h1>
-<div id="features-1" class="section level2">
+<div id="features-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-1" class="anchor"></a>Features</h2>
-<div id="full-support-for-es6-x" class="section level3">
+<a href="#features-2" class="anchor"></a>Features</h2>
+<div id="full-support-for-elasticsearch-6x" class="section level3">
 <h3 class="hasAnchor">
-<a href="#full-support-for-es6-x" class="anchor"></a>Full support for Elasticsearch 6.x</h3>
+<a href="#full-support-for-elasticsearch-6x" class="anchor"></a>Full support for Elasticsearch 6.x</h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues/64'>#64</a></a> added support for Elasticsearch 6.x. The biggest change between that major version and v5.x is that as of Elasticsearch 6.x all requests issued to the Elasticsearch HTTP API must pass an explicit <code>Content-Type</code> header. Previous versions of Elasticsearch tried to guess the <code>Content-Type</code> when none was declared</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues64'>#64</a></a> added support for Elasticsearch 6.x. The biggest change between that major version and v5.x is that as of Elasticsearch 6.x all requests issued to the Elasticsearch HTTP API must pass an explicit <code>Content-Type</code> header. Previous versions of Elasticsearch tried to guess the <code>Content-Type</code> when none was declared</li>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> completed support for Elasticsearch 6.x. Elasticsearch 6.x changed the supported strategy for issuing scrolling requests. <code>uptasticsearch</code> will now hit the cluster to try to figure out which version of Elasticsearch it is running, then use the appropriate scrolling strategy.</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues66'>#66</a></a> completed support for Elasticsearch 6.x. Elasticsearch 6.x changed the supported strategy for issuing scrolling requests. <code>uptasticsearch</code> will now hit the cluster to try to figure out which version of Elasticsearch it is running, then use the appropriate scrolling strategy.</li>
 </ul>
 </div>
 </div>
@@ -182,28 +193,28 @@
 <h3 class="hasAnchor">
 <a href="#get_fields-when-your-index-has-no-aliases" class="anchor"></a><code>get_fields()</code> when your index has no aliases</h3>
 <ul>
-<li>previously, <code>get_fields()</code> broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the <code>_cat/aliases</code> endpoint has changed from major version to major version. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> fixed this for all major versions of Elasticsearch from 1.0 to 6.2</li>
+<li>previously, <code><a href="../reference/get_fields.html">get_fields()</a></code> broke on some legacy versions of Elasticsearch where no aliases had been created. The response on the <code>_cat/aliases</code> endpoint has changed from major version to major version. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues66'>#66</a></a> fixed this for all major versions of Elasticsearch from 1.0 to 6.2</li>
 </ul>
 </div>
 <div id="get_fields-when-your-index-has-multiple-aliases" class="section level3">
 <h3 class="hasAnchor">
 <a href="#get_fields-when-your-index-has-multiple-aliases" class="anchor"></a><code>get_fields()</code> when your index has multiple aliases</h3>
 <ul>
-<li>previously, if you had multiple aliases pointing to the same physical index, <code>get_fields()</code> would only return one of those. As of <a href="https://github.com/uptake/uptasticsearch/pull/73"><a href='https://github.com/uptake/uptasticsearch/issues/73'>#73</a></a>, mappings for the underlying physical index will now be duplicated once per alias in the table returned by <code>get_fields()</code>.</li>
+<li>previously, if you had multiple aliases pointing to the same physical index, <code><a href="../reference/get_fields.html">get_fields()</a></code> would only return one of those. As of <a href="https://github.com/uptake/uptasticsearch/pull/73"><a href='https://github.com/uptake/uptasticsearch/issues73'>#73</a></a>, mappings for the underlying physical index will now be duplicated once per alias in the table returned by <code><a href="../reference/get_fields.html">get_fields()</a></code>.</li>
 </ul>
 </div>
-<div id="bad-parsing-of-es-major-version" class="section level3">
+<div id="bad-parsing-of-elasticsearch-major-version" class="section level3">
 <h3 class="hasAnchor">
-<a href="#bad-parsing-of-es-major-version" class="anchor"></a>bad parsing of Elasticsearch major version</h3>
+<a href="#bad-parsing-of-elasticsearch-major-version" class="anchor"></a>bad parsing of Elasticsearch major version</h3>
 <ul>
-<li>as of <a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues/64'>#64</a></a>, <code>uptasticsearch</code> attempts to query the Elasticsearch host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a>. NOTE: this only impacted the dev version of the library on Github.</li>
+<li>as of <a href="https://github.com/uptake/uptasticsearch/pull/64"><a href='https://github.com/uptake/uptasticsearch/issues64'>#64</a></a>, <code>uptasticsearch</code> attempts to query the Elasticsearch host to figure out what major version of Elasticsearch is running there. Implementation errors in that PR led to versions being parsed incorrectly but silently passing tests. This was fixed in <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues66'>#66</a></a>. NOTE: this only impacted the dev version of the library on Github.</li>
 </ul>
 </div>
 <div id="ignore_scroll_restriction-not-being-respected" class="section level3">
 <h3 class="hasAnchor">
 <a href="#ignore_scroll_restriction-not-being-respected" class="anchor"></a><code>ignore_scroll_restriction</code> not being respected</h3>
 <ul>
-<li>In previous versions of <code>uptasticsearch</code>, the value passed to <code>es_search()</code> for <code>ignore_scroll_restriction</code> was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn’t getting passed through. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues/66'>#66</a></a> instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won’t be able to silently get through testing in the future.</li>
+<li>In previous versions of <code>uptasticsearch</code>, the value passed to <code><a href="../reference/es_search.html">es_search()</a></code> for <code>ignore_scroll_restriction</code> was not actually respected. This was possible because an internal function had defaults specified, so we never caught the fact that that value wasn’t getting passed through. <a href="https://github.com/uptake/uptasticsearch/pull/66"><a href='https://github.com/uptake/uptasticsearch/issues66'>#66</a></a> instituted the practice of not specifying defaults on function arguments in internal functions, so similar bugs won’t be able to silently get through testing in the future.</li>
 </ul>
 </div>
 </div>
@@ -212,48 +223,48 @@
 <a href="#deprecations-and-removals" class="anchor"></a>Deprecations and Removals</h2>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/69"><a href='https://github.com/uptake/uptasticsearch/issues/69'>#69</a></a> added a deprecation warning on <code>get_counts</code>. This function was outside the core mission of the package and exposed us unnecessarily to changes in the Elasticsearch DSL</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/69"><a href='https://github.com/uptake/uptasticsearch/issues69'>#69</a></a> added a deprecation warning on <code>get_counts()</code>. This function was outside the core mission of the package and exposed us unnecessarily to changes in the Elasticsearch DSL</li>
 </ul>
 </div>
 </div>
-    <div id="uptasticsearch-0-2-0" class="section level1">
-<h1 class="page-header">
-<a href="#uptasticsearch-0-2-0" class="anchor"></a>uptasticsearch 0.2.0<small> 2018-04-13 </small>
+    <div id="uptasticsearch-020" class="section level1">
+<h1 class="page-header" data-toc-text="0.2.0">
+<a href="#uptasticsearch-020" class="anchor"></a>uptasticsearch 0.2.0<small> 2018-04-13 </small>
 </h1>
-<div id="features-2" class="section level2">
+<div id="features-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-2" class="anchor"></a>Features</h2>
+<a href="#features-3" class="anchor"></a>Features</h2>
 <div id="faster-unpack_nested_data" class="section level3">
 <h3 class="hasAnchor">
 <a href="#faster-unpack_nested_data" class="anchor"></a>Faster <code>unpack_nested_data()</code>
 </h3>
 <ul>
 <li>
-<a href="https://github.com/uptake/uptasticsearch/pull/51"><a href='https://github.com/uptake/uptasticsearch/issues/51'>#51</a></a> changed the parsing strategy for nested data and made it 9x faster than the previous implementation</li>
+<a href="https://github.com/uptake/uptasticsearch/pull/51"><a href='https://github.com/uptake/uptasticsearch/issues51'>#51</a></a> changed the parsing strategy for nested data and made it 9x faster than the previous implementation</li>
 </ul>
 </div>
 <div id="retry-logic" class="section level3">
 <h3 class="hasAnchor">
 <a href="#retry-logic" class="anchor"></a>Retry logic</h3>
 <ul>
-<li>Functions that make HTTP calls will now use retry logic via <code><a href="https://www.rdocumentation.org/packages/httr/topics/RETRY">httr::RETRY</a></code> instead of one-shot <code>POST</code> or <code>GET</code> calls</li>
+<li>Functions that make HTTP calls will now use retry logic via <code><a href="https://httr.r-lib.org/reference/RETRY.html">httr::RETRY</a></code> instead of one-shot <code>POST</code> or <code>GET</code> calls</li>
 </ul>
 </div>
 </div>
 </div>
-    <div id="uptasticsearch-0-1-0" class="section level1">
-<h1 class="page-header">
-<a href="#uptasticsearch-0-1-0" class="anchor"></a>uptasticsearch 0.1.0<small> 2017-08-29 </small>
+    <div id="uptasticsearch-010" class="section level1">
+<h1 class="page-header" data-toc-text="0.1.0">
+<a href="#uptasticsearch-010" class="anchor"></a>uptasticsearch 0.1.0<small> 2017-08-29 </small>
 </h1>
-<div id="features-3" class="section level2">
+<div id="features-4" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-3" class="anchor"></a>Features</h2>
+<a href="#features-4" class="anchor"></a>Features</h2>
 <div id="elasticsearch-metadata" class="section level3">
 <h3 class="hasAnchor">
 <a href="#elasticsearch-metadata" class="anchor"></a>Elasticsearch metadata</h3>
 <ul>
 <li>
-<code>get_fields()</code> returns a data.table with the names and types of all indexed fields across one or more indices</li>
+<code><a href="../reference/get_fields.html">get_fields()</a></code> returns a data.table with the names and types of all indexed fields across one or more indices</li>
 </ul>
 </div>
 <div id="routing-temporary-file-writing" class="section level3">
@@ -261,7 +272,7 @@
 <a href="#routing-temporary-file-writing" class="anchor"></a>Routing Temporary File Writing</h3>
 <ul>
 <li>
-<code>es_search()</code> now accepts an <code>intermediates_dir</code> parameter, giving users control over the directory used for temporary I/O at query time</li>
+<code><a href="../reference/es_search.html">es_search()</a></code> now accepts an <code>intermediates_dir</code> parameter, giving users control over the directory used for temporary I/O at query time</li>
 </ul>
 </div>
 </div>
@@ -277,29 +288,29 @@
 </div>
 </div>
 </div>
-    <div id="uptasticsearch-0-0-2" class="section level1">
-<h1 class="page-header">
-<a href="#uptasticsearch-0-0-2" class="anchor"></a>uptasticsearch 0.0.2<small> 2017-07-18 </small>
+    <div id="uptasticsearch-002" class="section level1">
+<h1 class="page-header" data-toc-text="0.0.2">
+<a href="#uptasticsearch-002" class="anchor"></a>uptasticsearch 0.0.2<small> 2017-07-18 </small>
 </h1>
-<div id="features-4" class="section level2">
+<div id="features-5" class="section level2">
 <h2 class="hasAnchor">
-<a href="#features-4" class="anchor"></a>Features</h2>
+<a href="#features-5" class="anchor"></a>Features</h2>
 <div id="main-function" class="section level3">
 <h3 class="hasAnchor">
 <a href="#main-function" class="anchor"></a>Main function</h3>
 <ul>
 <li>
-<code>es_search()</code> executes an Elasticsearch query and gets a data.table</li>
+<code><a href="../reference/es_search.html">es_search()</a></code> executes an Elasticsearch query and gets a data.table</li>
 </ul>
 </div>
-<div id="parse-raw-json-into-data-table" class="section level3">
+<div id="parse-raw-json-into-datatable" class="section level3">
 <h3 class="hasAnchor">
-<a href="#parse-raw-json-into-data-table" class="anchor"></a>Parse raw JSON into data.table</h3>
+<a href="#parse-raw-json-into-datatable" class="anchor"></a>Parse raw JSON into data.table</h3>
 <ul>
 <li>
-<code>chomp_aggs()</code> converts a raw aggs JSON to data.table</li>
+<code><a href="../reference/chomp_aggs.html">chomp_aggs()</a></code> converts a raw aggs JSON to data.table</li>
 <li>
-<code>chomp_hits()</code> converts a raw hits JSON to data.table</li>
+<code><a href="../reference/chomp_hits.html">chomp_hits()</a></code> converts a raw hits JSON to data.table</li>
 </ul>
 </div>
 <div id="utilities" class="section level3">
@@ -307,9 +318,9 @@
 <a href="#utilities" class="anchor"></a>Utilities</h3>
 <ul>
 <li>
-<code>unpack_nested_data()</code> deals with nested Elasticsearch data not in a tabular format</li>
+<code><a href="../reference/unpack_nested_data.html">unpack_nested_data()</a></code> deals with nested Elasticsearch data not in a tabular format</li>
 <li>
-<code>parse_date_time()</code> parses date-times from Elasticsearch records</li>
+<code><a href="../reference/parse_date_time.html">parse_date_time()</a></code> parses date-times from Elasticsearch records</li>
 </ul>
 </div>
 <div id="exploratory-functions" class="section level3">
@@ -324,21 +335,14 @@
 </div>
   </div>
 
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <div id="tocnav">
-      <h2>Contents</h2>
-      <ul class="nav nav-pills nav-stacked">
-        <li><a href="#uptasticsearch-0-4-0">0.4.0</a></li>
-        <li><a href="#uptasticsearch-0-3-1">0.3.1</a></li>
-        <li><a href="#uptasticsearch-0-3-0">0.3.0</a></li>
-        <li><a href="#uptasticsearch-0-2-0">0.2.0</a></li>
-        <li><a href="#uptasticsearch-0-1-0">0.1.0</a></li>
-        <li><a href="#uptasticsearch-0-0-2">0.0.2</a></li>
-      </ul>
-    </div>
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -346,13 +350,16 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/pkgdown.css
+++ b/docs/pkgdown.css
@@ -17,12 +17,14 @@ html, body {
   height: 100%;
 }
 
+body {
+  position: relative;
+}
+
 body > .container {
   display: flex;
   height: 100%;
   flex-direction: column;
-
-  padding-top: 60px;
 }
 
 body > .container .row {
@@ -69,6 +71,10 @@ summary {
   margin-top: calc(-60px + 1em);
 }
 
+dd {
+  margin-left: 3em;
+}
+
 /* Section anchors ---------------------------------*/
 
 a.anchor {
@@ -102,37 +108,135 @@ a.anchor {
   margin-top: -40px;
 }
 
-/* Static header placement on mobile devices */
-@media (max-width: 767px) {
-  .navbar-fixed-top {
-    position: absolute;
-  }
-  .navbar {
-    padding: 0;
-  }
+/* Navbar submenu --------------------------*/
+
+.dropdown-submenu {
+  position: relative;
 }
 
+.dropdown-submenu>.dropdown-menu {
+  top: 0;
+  left: 100%;
+  margin-top: -6px;
+  margin-left: -1px;
+  border-radius: 0 6px 6px 6px;
+}
+
+.dropdown-submenu:hover>.dropdown-menu {
+  display: block;
+}
+
+.dropdown-submenu>a:after {
+  display: block;
+  content: " ";
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 5px 0 5px 5px;
+  border-left-color: #cccccc;
+  margin-top: 5px;
+  margin-right: -10px;
+}
+
+.dropdown-submenu:hover>a:after {
+  border-left-color: #ffffff;
+}
+
+.dropdown-submenu.pull-left {
+  float: none;
+}
+
+.dropdown-submenu.pull-left>.dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+  border-radius: 6px 0 6px 6px;
+}
 
 /* Sidebar --------------------------*/
 
-#sidebar {
+#pkgdown-sidebar {
   margin-top: 30px;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 70px;
 }
-#sidebar h2 {
+
+#pkgdown-sidebar h2 {
   font-size: 1.5em;
   margin-top: 1em;
 }
 
-#sidebar h2:first-child {
+#pkgdown-sidebar h2:first-child {
   margin-top: 0;
 }
 
-#sidebar .list-unstyled li {
+#pkgdown-sidebar .list-unstyled li {
   margin-bottom: 0.5em;
 }
 
+/* bootstrap-toc tweaks ------------------------------------------------------*/
+
+/* All levels of nav */
+
+nav[data-toggle='toc'] .nav > li > a {
+  padding: 4px 20px 4px 6px;
+  font-size: 1.5rem;
+  font-weight: 400;
+  color: inherit;
+}
+
+nav[data-toggle='toc'] .nav > li > a:hover,
+nav[data-toggle='toc'] .nav > li > a:focus {
+  padding-left: 5px;
+  color: inherit;
+  border-left: 1px solid #878787;
+}
+
+nav[data-toggle='toc'] .nav > .active > a,
+nav[data-toggle='toc'] .nav > .active:hover > a,
+nav[data-toggle='toc'] .nav > .active:focus > a {
+  padding-left: 5px;
+  font-size: 1.5rem;
+  font-weight: 400;
+  color: inherit;
+  border-left: 2px solid #878787;
+}
+
+/* Nav: second level (shown on .active) */
+
+nav[data-toggle='toc'] .nav .nav {
+  display: none; /* Hide by default, but at >768px, show it */
+  padding-bottom: 10px;
+}
+
+nav[data-toggle='toc'] .nav .nav > li > a {
+  padding-left: 16px;
+  font-size: 1.35rem;
+}
+
+nav[data-toggle='toc'] .nav .nav > li > a:hover,
+nav[data-toggle='toc'] .nav .nav > li > a:focus {
+  padding-left: 15px;
+}
+
+nav[data-toggle='toc'] .nav .nav > .active > a,
+nav[data-toggle='toc'] .nav .nav > .active:hover > a,
+nav[data-toggle='toc'] .nav .nav > .active:focus > a {
+  padding-left: 15px;
+  font-weight: 500;
+  font-size: 1.35rem;
+}
+
+/* orcid ------------------------------------------------------------------- */
+
 .orcid {
-  height: 16px;
+  font-size: 16px;
+  color: #A6CE39;
+  /* margins are required by official ORCID trademark and display guidelines */
+  margin-left:4px;
+  margin-right:4px;
   vertical-align: middle;
 }
 
@@ -222,6 +326,19 @@ a.sourceLine:hover {
   visibility: visible;
 }
 
+/* headroom.js ------------------------ */
+
+.headroom {
+  will-change: transform;
+  transition: transform 200ms linear;
+}
+.headroom--pinned {
+  transform: translateY(0%);
+}
+.headroom--unpinned {
+  transform: translateY(-100%);
+}
+
 /* mark.js ----------------------------*/
 
 mark {
@@ -233,4 +350,18 @@ mark {
 /* vertical spacing after htmlwidgets */
 .html-widget {
   margin-bottom: 10px;
+}
+
+/* fontawesome ------------------------ */
+
+.fab {
+    font-family: "Font Awesome 5 Brands" !important;
+}
+
+/* don't display links in code chunks when printing */
+/* source: https://stackoverflow.com/a/10781533 */
+@media print {
+  code a:link:after, code a:visited:after {
+    content: "";
+  }
 }

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -2,18 +2,11 @@
 (function($) {
   $(function() {
 
-    $("#sidebar")
-      .stick_in_parent({offset_top: 40})
-      .on('sticky_kit:bottom', function(e) {
-        $(this).parent().css('position', 'static');
-      })
-      .on('sticky_kit:unbottom', function(e) {
-        $(this).parent().css('position', 'relative');
-      });
+    $('.navbar-fixed-top').headroom();
 
-    $('body').scrollspy({
-      target: '#sidebar',
-      offset: 60
+    $('body').css('padding-top', $('.navbar').height() + 10);
+    $(window).resize(function(){
+      $('body').css('padding-top', $('.navbar').height() + 10);
     });
 
     $('[data-toggle="tooltip"]').tooltip();

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,6 +1,7 @@
-pandoc: 2.3.1
-pkgdown: 1.3.0
+pandoc: 2.9.2
+pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   FAQ: FAQ.html
+last_built: 2020-05-12T04:27Z
 

--- a/docs/reference/chomp_aggs.html
+++ b/docs/reference/chomp_aggs.html
@@ -6,23 +6,31 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Aggs query to data.table — chomp_aggs() • uptasticsearch</title>
+<title>Aggs query to data.table — chomp_aggs • uptasticsearch</title>
+
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,11 +38,11 @@
 
 
 
-<meta property="og:title" content="Aggs query to data.table — chomp_aggs()" />
 
+<meta property="og:title" content="Aggs query to data.table — chomp_aggs" />
 <meta property="og:description" content="Given some raw JSON from an aggs query in Elasticsearch, parse the
              aggregations into a data.table." />
-<meta name="twitter:card" content="summary" />
+
 
 
 
@@ -48,9 +56,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -64,7 +73,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -72,7 +81,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -95,11 +104,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -110,40 +118,38 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Aggs query to data.table</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/chomp_aggs.R'><code>R/chomp_aggs.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/chomp_aggs.R'><code>R/chomp_aggs.R</code></a></small>
     <div class="hidden name"><code>chomp_aggs.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
     <p>Given some raw JSON from an aggs query in Elasticsearch, parse the
              aggregations into a data.table.</p>
-    
     </div>
 
     <pre class="usage"><span class='fu'>chomp_aggs</span>(<span class='kw'>aggs_json</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
-    
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>aggs_json</th>
       <td><p>A character vector. If its length is greater than 1, its elements will be pasted
-together. This can contain a JSON returned from an <code>aggs</code> query in Elasticsearch, or
-a filepath or URL pointing at one.</p></td>
+together. This can contain a JSON returned from an <code>aggs</code> query in
+Elasticsearch, or a filepath or URL pointing at one.</p></td>
     </tr>
     </table>
-    
+
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
     <p>A data.table representation of the result or NULL if the aggregation result is empty.</p>
-    
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='co'># A sample raw result from an aggs query combining date_histogram and extended_stats:</span>
@@ -157,7 +163,7 @@ a filepath or URL pointing at one.</p></td>
 
 <span class='co'># Parse into a data.table</span>
 <span class='no'>aggDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_aggs</span>(<span class='kw'>aggs_json</span> <span class='kw'>=</span> <span class='no'>result</span>)
-<span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>aggDT</span>)</div><div class='output co'>#&gt;                    dateTime num_potatoes.count num_potatoes.min
+<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>aggDT</span>)</div><div class='output co'>#&gt;                    dateTime num_potatoes.count num_potatoes.min
 #&gt; 1: 2016-12-01T00:00:00.000Z                120                0
 #&gt; 2: 2017-01-01T00:00:00.000Z                131                0
 #&gt;    num_potatoes.max num_potatoes.avg num_potatoes.sum
@@ -173,18 +179,13 @@ a filepath or URL pointing at one.</p></td>
 #&gt; 1:                                      13       123
 #&gt; 2:                                      13       134</div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-      
-      <li><a href="#value">Value</a></li>
-      
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -192,13 +193,16 @@ a filepath or URL pointing at one.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/chomp_hits.html
+++ b/docs/reference/chomp_hits.html
@@ -6,23 +6,31 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Hits to data.tables — chomp_hits() • uptasticsearch</title>
+<title>Hits to data.tables — chomp_hits • uptasticsearch</title>
+
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,12 +38,12 @@
 
 
 
-<meta property="og:title" content="Hits to data.tables — chomp_hits()" />
 
+<meta property="og:title" content="Hits to data.tables — chomp_hits" />
 <meta property="og:description" content="A function for converting Elasticsearch docs into R data.tables. It
              uses fromJSON with flatten = TRUE to convert a
              JSON into an R data.frame, and formats it into a data.table." />
-<meta name="twitter:card" content="summary" />
+
 
 
 
@@ -49,9 +57,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -65,7 +74,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -73,7 +82,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -96,11 +105,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -111,26 +119,25 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Hits to data.tables</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/chomp_hits.R'><code>R/chomp_hits.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/chomp_hits.R'><code>R/chomp_hits.R</code></a></small>
     <div class="hidden name"><code>chomp_hits.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
     <p>A function for converting Elasticsearch docs into R data.tables. It
-             uses <code><a href='https://www.rdocumentation.org/packages/jsonlite/topics/fromJSON'>fromJSON</a></code> with <code>flatten = TRUE</code> to convert a
+             uses <code><a href='https://jeroen.cran.dev/jsonlite/reference/fromJSON.html'>fromJSON</a></code> with <code>flatten = TRUE</code> to convert a
              JSON into an R data.frame, and formats it into a data.table.</p>
-    
     </div>
 
     <pre class="usage"><span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
-    
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
@@ -147,7 +154,7 @@ arrays in the original JSON. A warning will be given if these
 columns are deleted.</p></td>
     </tr>
     </table>
-    
+
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='co'># A sample raw result from a hits query:</span>
@@ -164,8 +171,8 @@ columns are deleted.</p></td>
 "film":"Avengers: Infinity War","pmt_amount":12.75}]}}}]'</span>
 
 <span class='co'># Chomp into a data.table</span>
-<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2019-09-09 21:22:29] Keeping the following nested data columns. Consider using unpack_nested_data for one:
-#&gt;  details.pastPurchases</div><div class='input'><span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
+<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2020-05-11 23:27:37] Keeping the following nested data columns. Consider using unpack_nested_data for one:
+#&gt;  details.pastPurchases</div><div class='input'><span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
 #&gt; 1: 2017-01-01    Austin        big_spender          chicago
 #&gt; 2: 2017-02-02     James            peasant          chicago
 #&gt; 3: 2017-03-03      Nick             critic           cannes
@@ -178,7 +185,7 @@ columns are deleted.</p></td>
 <span class='co'># Unpack by details.pastPurchases</span>
 <span class='no'>unpackedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='unpack_nested_data.html'>unpack_nested_data</a></span>(<span class='kw'>chomped_df</span> <span class='kw'>=</span> <span class='no'>sampleChompedDT</span>
                                  , <span class='kw'>col_to_unpack</span> <span class='kw'>=</span> <span class='st'>"details.pastPurchases"</span>)
-<span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>unpackedDT</span>)</div><div class='output co'>#&gt;      timestamp cust_name details.cust_class details.location
+<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>unpackedDT</span>)</div><div class='output co'>#&gt;      timestamp cust_name details.cust_class details.location
 #&gt;  1: 2017-01-01    Austin        big_spender          chicago
 #&gt;  2: 2017-01-01    Austin        big_spender          chicago
 #&gt;  3: 2017-01-01    Austin        big_spender          chicago
@@ -201,16 +208,13 @@ columns are deleted.</p></td>
 #&gt;  9: Dopo la guerra (Apres la Guerre)       0.00    TRUE
 #&gt; 10:           Avengers: Infinity War      12.75      NA</div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-            
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -218,13 +222,16 @@ columns are deleted.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/doc_shared.html
+++ b/docs/reference/doc_shared.html
@@ -8,21 +8,29 @@
 
 <title>NULL Object For Common Documentation — doc_shared • uptasticsearch</title>
 
-<!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<!-- jquery -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+<!-- Bootstrap -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,11 +38,11 @@
 
 
 
-<meta property="og:title" content="NULL Object For Common Documentation — doc_shared" />
 
+<meta property="og:title" content="NULL Object For Common Documentation — doc_shared" />
 <meta property="og:description" content="This is a NULL object with documentation so that later functions can call
 inheritParams" />
-<meta name="twitter:card" content="summary" />
+
 
 
 
@@ -48,9 +56,10 @@ inheritParams" />
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -64,7 +73,7 @@ inheritParams" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -72,7 +81,7 @@ inheritParams" />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -95,11 +104,10 @@ inheritParams" />
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -110,30 +118,29 @@ inheritParams" />
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>NULL Object For Common Documentation</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/uptasticsearch.R'><code>R/uptasticsearch.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/uptasticsearch.R'><code>R/uptasticsearch.R</code></a></small>
     <div class="hidden name"><code>doc_shared.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
     <p>This is a NULL object with documentation so that later functions can call
 inheritParams</p>
-    
     </div>
 
-    
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>es_host</th>
-      <td><p>A string identifying an Elasticsearch host. This should be of the form 
+      <td><p>A string identifying an Elasticsearch host. This should be of the form
 <code>[transfer_protocol][hostname]:[port]</code>. For example, <code>'http://myindex.thing.com:9200'</code>.</p></td>
     </tr>
     <tr>
@@ -146,17 +153,16 @@ uptasticsearch forbids this. If you want to execute a query over
 all indexes in the cluster, set this argument to <code>"_all"</code>.</p></td>
     </tr>
     </table>
-    
+
 
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-                </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -164,13 +170,16 @@ all indexes in the cluster, set this argument to <code>"_all"</code>.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/es_search.html
+++ b/docs/reference/es_search.html
@@ -6,23 +6,31 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Execute an Elasticsearch query and get a data.table — es_search() • uptasticsearch</title>
+<title>Execute an Elasticsearch query and get a data.table — es_search • uptasticsearch</title>
+
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,12 +38,12 @@
 
 
 
-<meta property="og:title" content="Execute an Elasticsearch query and get a data.table — es_search()" />
 
-<meta property="og:description" content="Given a query and some optional parameters, es_search() gets results
+<meta property="og:title" content="Execute an Elasticsearch query and get a data.table — es_search" />
+<meta property="og:description" content="Given a query and some optional parameters, es_search gets results
              from HTTP requests to Elasticsearch and returns a data.table
              representation of those results." />
-<meta name="twitter:card" content="summary" />
+
 
 
 
@@ -49,9 +57,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -65,7 +74,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -73,7 +82,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -96,11 +105,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -111,36 +119,42 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Execute an Elasticsearch query and get a data.table</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/es_search.R'><code>R/es_search.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/es_search.R'><code>R/es_search.R</code></a></small>
     <div class="hidden name"><code>es_search.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
-    <p>Given a query and some optional parameters, <code>es_search()</code> gets results
+    <p>Given a query and some optional parameters, <code>es_search</code> gets results
              from HTTP requests to Elasticsearch and returns a data.table
              representation of those results.</p>
-    
     </div>
 
-    <pre class="usage"><span class='fu'>es_search</span>(<span class='no'>es_host</span>, <span class='no'>es_index</span>, <span class='kw'>size</span> <span class='kw'>=</span> <span class='fl'>10000</span>, <span class='kw'>query_body</span> <span class='kw'>=</span> <span class='st'>"{}"</span>,
-  <span class='kw'>scroll</span> <span class='kw'>=</span> <span class='st'>"5m"</span>, <span class='kw'>max_hits</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
-  <span class='kw'>n_cores</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/Round'>ceiling</a></span>(<span class='kw pkg'>parallel</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/parallel/topics/detectCores'>detectCores</a></span>()/<span class='fl'>2</span>),
-  <span class='kw'>break_on_duplicates</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>ignore_scroll_restriction</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>intermediates_dir</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/getwd'>getwd</a></span>())</pre>
-    
+    <pre class="usage"><span class='fu'>es_search</span>(
+  <span class='no'>es_host</span>,
+  <span class='no'>es_index</span>,
+  <span class='kw'>size</span> <span class='kw'>=</span> <span class='fl'>10000</span>,
+  <span class='kw'>query_body</span> <span class='kw'>=</span> <span class='st'>"{}"</span>,
+  <span class='kw'>scroll</span> <span class='kw'>=</span> <span class='st'>"5m"</span>,
+  <span class='kw'>max_hits</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
+  <span class='kw'>n_cores</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/Round.html'>ceiling</a></span>(<span class='kw pkg'>parallel</span><span class='kw ns'>::</span><span class='fu'><a href='https://rdrr.io/r/parallel/detectCores.html'>detectCores</a></span>()/<span class='fl'>2</span>),
+  <span class='kw'>break_on_duplicates</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+  <span class='kw'>ignore_scroll_restriction</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>intermediates_dir</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/getwd.html'>getwd</a></span>()
+)</pre>
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>es_host</th>
-      <td><p>A string identifying an Elasticsearch host. This should be of the form 
+      <td><p>A string identifying an Elasticsearch host. This should be of the form
 <code>[transfer_protocol][hostname]:[port]</code>. For example, <code>'http://myindex.thing.com:9200'</code>.</p></td>
     </tr>
     <tr>
@@ -154,7 +168,8 @@ all indexes in the cluster, set this argument to <code>"_all"</code>.</p></td>
     </tr>
     <tr>
       <th>size</th>
-      <td><p>Number of records per page of results. See <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html'>Elasticsearch docs</a> for more.
+      <td><p>Number of records per page of results.
+See <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html'>Elasticsearch docs</a> for more.
 Note that this will be reset to 0 if you submit a <code>query_body</code> with
 an "aggs" request in it. Also see <code>max_hits</code>.</p></td>
     </tr>
@@ -174,7 +189,7 @@ for more information.</p></td>
     </tr>
     <tr>
       <th>max_hits</th>
-      <td><p>Integer. If specified, <code>es_search()</code> will stop pulling data as soon
+      <td><p>Integer. If specified, <code>es_search</code> will stop pulling data as soon
 as it has pulled this many hits. Default is <code>Inf</code>, meaning that
 all possible hits will be pulled.</p></td>
     </tr>
@@ -184,10 +199,11 @@ all possible hits will be pulled.</p></td>
     </tr>
     <tr>
       <th>break_on_duplicates</th>
-      <td><p>Boolean, defaults to TRUE. <code>es_search()</code> uses the size of the final object it returns
-to check whether or not some data were lost during the processing.
-If you have duplicates in the source data, you will have to set this flag to
-FALSE and just trust that no data have been lost. Sorry :( .</p></td>
+      <td><p>Boolean, defaults to TRUE. <code>es_search</code> uses the size of the
+final object it returns to check whether or not some data were lost
+during the processing. If you have duplicates in the source data, you
+will have to set this flag to FALSE and just trust that no data have
+been lost. Sorry :( .</p></td>
     </tr>
     <tr>
       <th>ignore_scroll_restriction</th>
@@ -204,20 +220,20 @@ to <code>TRUE</code>.</p></td>
     <tr>
       <th>intermediates_dir</th>
       <td><p>When scrolling over search results, this function writes
-intermediate results to disk. By default, <code>es_search()</code> will create a temporary
+intermediate results to disk. By default, `es_search` will create a temporary
 directory in whatever working directory the function is called from. If you
-want to change this behavior, provide a path here. <code>es_search()</code> will create
+want to change this behavior, provide a path here. `es_search` will create
 and write to a temporary directory under whatever path you provide.</p></td>
     </tr>
     </table>
-    
+
     <h2 class="hasAnchor" id="references"><a class="anchor" href="#references"></a>References</h2>
 
     <p><a href='https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html'>Elasticsearch 6 scrolling strategy</a></p>
-    
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><span class='co'># NOT RUN {</span>
+    <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+
 <span class='co'>###=== Example 1: Get low-scoring food survey results ===###</span>
 
 <span class='no'>query_body</span> <span class='kw'>&lt;-</span> <span class='st'>'{"query":{"filtered":{"filter":{"bool":{"must":[
@@ -244,20 +260,15 @@ and write to a temporary directory under whatever path you provide.</p></td>
 <span class='no'>resultDT</span> <span class='kw'>&lt;-</span> <span class='fu'>es_search</span>(<span class='kw'>es_host</span> <span class='kw'>=</span> <span class='st'>"http://es.custdb.mycompany.com:9200"</span>
                       , <span class='kw'>es_index</span> <span class='kw'>=</span> <span class='st'>'ticket_sales'</span>
                       , <span class='kw'>query_body</span> <span class='kw'>=</span> <span class='no'>query_body</span>)
-<span class='co'># }</span></pre>
+}</div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-      
-      <li><a href="#references">References</a></li>
-      
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -265,13 +276,16 @@ and write to a temporary directory under whatever path you provide.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/get_fields.html
+++ b/docs/reference/get_fields.html
@@ -6,23 +6,31 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get the names and data types of the indexed fields in an index — get_fields() • uptasticsearch</title>
+<title>Get the names and data types of the indexed fields in an index — get_fields • uptasticsearch</title>
+
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,11 +38,11 @@
 
 
 
-<meta property="og:title" content="Get the names and data types of the indexed fields in an index — get_fields()" />
 
+<meta property="og:title" content="Get the names and data types of the indexed fields in an index — get_fields" />
 <meta property="og:description" content="For a given Elasticsearch index, return the mapping from field name
              to data type for all indexed fields." />
-<meta name="twitter:card" content="summary" />
+
 
 
 
@@ -48,9 +56,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -64,7 +73,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -72,7 +81,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -95,11 +104,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -110,31 +118,30 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Get the names and data types of the indexed fields in an index</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/get_fields.R'><code>R/get_fields.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/get_fields.R'><code>R/get_fields.R</code></a></small>
     <div class="hidden name"><code>get_fields.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
     <p>For a given Elasticsearch index, return the mapping from field name
              to data type for all indexed fields.</p>
-    
     </div>
 
     <pre class="usage"><span class='fu'>get_fields</span>(<span class='no'>es_host</span>, <span class='kw'>es_indices</span> <span class='kw'>=</span> <span class='st'>"_all"</span>)</pre>
-    
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>es_host</th>
-      <td><p>A string identifying an Elasticsearch host. This should be of the form 
+      <td><p>A string identifying an Elasticsearch host. This should be of the form
 <code>[transfer_protocol][hostname]:[port]</code>. For example, <code>'http://myindex.thing.com:9200'</code>.</p></td>
     </tr>
     <tr>
@@ -145,31 +152,25 @@ get the mapping for all indices. Names of indices can be
 treated as regular expressions.</p></td>
     </tr>
     </table>
-    
+
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
     <p>A data.table containing four columns: index, type, field, and data_type</p>
-    
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><span class='co'># NOT RUN {</span>
+    <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
 <span class='co'># get the mapping for all indexed fields in the ticket_sales and customers indices</span>
 <span class='no'>mappingDT</span> <span class='kw'>&lt;-</span> <span class='fu'>get_fields</span>(<span class='kw'>es_host</span> <span class='kw'>=</span> <span class='st'>"http://es.custdb.mycompany.com:9200"</span>
-                              , <span class='kw'>es_indices</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"ticket_sales"</span>, <span class='st'>"customers"</span>))
-<span class='co'># }</span></pre>
+                              , <span class='kw'>es_indices</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"ticket_sales"</span>, <span class='st'>"customers"</span>))
+}</div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-      
-      <li><a href="#value">Value</a></li>
-      
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -177,13 +178,16 @@ treated as regular expressions.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -8,21 +8,29 @@
 
 <title>Function reference • uptasticsearch</title>
 
-<!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<!-- jquery -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+<!-- Bootstrap -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,7 +38,9 @@
 
 
 
+
 <meta property="og:title" content="Function reference" />
+
 
 
 
@@ -44,9 +54,10 @@
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-index">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -60,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -68,7 +79,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -91,11 +102,10 @@
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -106,6 +116,7 @@
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
@@ -129,6 +140,11 @@
           <p class="section-desc"></p>
         </th>
       </tr>
+      
+      
+    </tbody><tbody>
+      
+      
       <tr>
         
         <td>
@@ -143,6 +159,11 @@
           <p class="section-desc"></p>
         </th>
       </tr>
+      
+      
+    </tbody><tbody>
+      
+      
       <tr>
         
         <td>
@@ -163,6 +184,11 @@
           <p class="section-desc"></p>
         </th>
       </tr>
+      
+      
+    </tbody><tbody>
+      
+      
       <tr>
         
         <td>
@@ -183,6 +209,11 @@
           <p class="section-desc"></p>
         </th>
       </tr>
+      
+      
+    </tbody><tbody>
+      
+      
       <tr>
         
         <td>
@@ -194,16 +225,13 @@
     </table>
   </div>
 
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#section-main-function">Main function</a></li>
-      <li><a href="#section-parse-raw-json-into-data-table">Parse raw JSON into data.table</a></li>
-      <li><a href="#section-utilities">Utilities</a></li>
-      <li><a href="#section-exploratory-functions">Exploratory functions</a></li>
-    </ul>
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -211,13 +239,16 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/parse_date_time.html
+++ b/docs/reference/parse_date_time.html
@@ -6,23 +6,31 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Parse date-times from Elasticsearch records — parse_date_time() • uptasticsearch</title>
+<title>Parse date-times from Elasticsearch records — parse_date_time • uptasticsearch</title>
+
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,15 +38,15 @@
 
 
 
-<meta property="og:title" content="Parse date-times from Elasticsearch records — parse_date_time()" />
 
+<meta property="og:title" content="Parse date-times from Elasticsearch records — parse_date_time" />
 <meta property="og:description" content="Given a data.table with date-time strings,
              this function converts those dates-times to type POSIXct with the appropriate
              time zone. Assumption is that dates are of the form &quot;2016-07-25T22:15:19Z&quot;
              where T is just a separator and the last letter is a military timezone.
 This is a side-effect-free function: it returns a new data.table and the
              input data.table is unmodified." />
-<meta name="twitter:card" content="summary" />
+
 
 
 
@@ -52,9 +60,10 @@ This is a side-effect-free function: it returns a new data.table and the
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -68,7 +77,7 @@ This is a side-effect-free function: it returns a new data.table and the
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -76,7 +85,7 @@ This is a side-effect-free function: it returns a new data.table and the
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -99,11 +108,10 @@ This is a side-effect-free function: it returns a new data.table and the
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -114,29 +122,28 @@ This is a side-effect-free function: it returns a new data.table and the
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Parse date-times from Elasticsearch records</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/parse_date_time.R'><code>R/parse_date_time.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/parse_date_time.R'><code>R/parse_date_time.R</code></a></small>
     <div class="hidden name"><code>parse_date_time.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
     <p>Given a data.table with date-time strings,
              this function converts those dates-times to type POSIXct with the appropriate
              time zone. Assumption is that dates are of the form "2016-07-25T22:15:19Z"
              where T is just a separator and the last letter is a military timezone.</p>
 <p>This is a side-effect-free function: it returns a new data.table and the
              input data.table is unmodified.</p>
-    
     </div>
 
     <pre class="usage"><span class='fu'>parse_date_time</span>(<span class='no'>input_df</span>, <span class='no'>date_cols</span>, <span class='kw'>assume_tz</span> <span class='kw'>=</span> <span class='st'>"UTC"</span>)</pre>
-    
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
@@ -154,23 +161,22 @@ string dates of the form "2016-07-25T22:15:19Z".</p></td>
       <td><p>Timezone to convert to if parsing fails. Default is UTC</p></td>
     </tr>
     </table>
-    
+
     <h2 class="hasAnchor" id="references"><a class="anchor" href="#references"></a>References</h2>
 
     <p><a href='https://www.timeanddate.com/time/zones/military'>https://www.timeanddate.com/time/zones/military</a></p>
 <p><a href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>https://en.wikipedia.org/wiki/List_of_tz_database_time_zones</a></p>
-    
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='co'># Sample es_search(), chomp_hits(), or chomp_aggs() output:</span>
-<span class='no'>someDT</span> <span class='kw'>&lt;-</span> <span class='kw pkg'>data.table</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/data.table/topics/data.table'>data.table</a></span>(<span class='kw'>id</span> <span class='kw'>=</span> <span class='fl'>1</span>:<span class='fl'>5</span>
-                                 , <span class='kw'>company</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"Apple"</span>, <span class='st'>"Apple"</span>, <span class='st'>"Banana"</span>, <span class='st'>"Banana"</span>, <span class='st'>"Cucumber"</span>)
-                                 , <span class='kw'>timestamp</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"2015-03-14T09:26:53B"</span>, <span class='st'>"2015-03-14T09:26:54B"</span>
+<span class='no'>someDT</span> <span class='kw'>&lt;-</span> <span class='kw pkg'>data.table</span><span class='kw ns'>::</span><span class='fu'><a href='https://Rdatatable.gitlab.io/data.table/reference/data.table.html'>data.table</a></span>(<span class='kw'>id</span> <span class='kw'>=</span> <span class='fl'>1</span>:<span class='fl'>5</span>
+                                 , <span class='kw'>company</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"Apple"</span>, <span class='st'>"Apple"</span>, <span class='st'>"Banana"</span>, <span class='st'>"Banana"</span>, <span class='st'>"Cucumber"</span>)
+                                 , <span class='kw'>timestamp</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"2015-03-14T09:26:53B"</span>, <span class='st'>"2015-03-14T09:26:54B"</span>
                                                  , <span class='st'>"2031-06-28T08:53:07Z"</span>, <span class='st'>"2031-06-28T08:53:08Z"</span>
                                                  , <span class='st'>"2000-01-01"</span>))
 
 <span class='co'># Note that the date field is character right now</span>
-<span class='fu'><a href='https://www.rdocumentation.org/packages/utils/topics/str'>str</a></span>(<span class='no'>someDT</span>)</div><div class='output co'>#&gt; Classes ‘data.table’ and 'data.frame':	5 obs. of  3 variables:
+<span class='fu'><a href='https://rdrr.io/r/utils/str.html'>str</a></span>(<span class='no'>someDT</span>)</div><div class='output co'>#&gt; Classes ‘data.table’ and 'data.frame':	5 obs. of  3 variables:
 #&gt;  $ id       : int  1 2 3 4 5
 #&gt;  $ company  : chr  "Apple" "Apple" "Banana" "Banana" ...
 #&gt;  $ timestamp: chr  "2015-03-14T09:26:53B" "2015-03-14T09:26:54B" "2031-06-28T08:53:07Z" "2031-06-28T08:53:08Z" ...
@@ -179,24 +185,19 @@ string dates of the form "2016-07-25T22:15:19Z".</p></td>
 <span class='no'>someDT</span> <span class='kw'>&lt;-</span> <span class='fu'>parse_date_time</span>(<span class='kw'>input_df</span> <span class='kw'>=</span> <span class='no'>someDT</span>
                           , <span class='kw'>date_cols</span> <span class='kw'>=</span> <span class='st'>"timestamp"</span>
                           , <span class='kw'>assume_tz</span> <span class='kw'>=</span> <span class='st'>"UTC"</span>)
-<span class='fu'><a href='https://www.rdocumentation.org/packages/utils/topics/str'>str</a></span>(<span class='no'>someDT</span>)</div><div class='output co'>#&gt; Classes ‘data.table’ and 'data.frame':	5 obs. of  3 variables:
+<span class='fu'><a href='https://rdrr.io/r/utils/str.html'>str</a></span>(<span class='no'>someDT</span>)</div><div class='output co'>#&gt; Classes ‘data.table’ and 'data.frame':	5 obs. of  3 variables:
 #&gt;  $ id       : int  1 2 3 4 5
 #&gt;  $ company  : chr  "Apple" "Apple" "Banana" "Banana" ...
 #&gt;  $ timestamp: POSIXct, format: "2015-03-14 07:26:53" "2015-03-14 07:26:54" ...
 #&gt;  - attr(*, ".internal.selfref")=&lt;externalptr&gt; </div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-      
-      <li><a href="#references">References</a></li>
-      
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -204,13 +205,16 @@ string dates of the form "2016-07-25T22:15:19Z".</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/docs/reference/unpack_nested_data.html
+++ b/docs/reference/unpack_nested_data.html
@@ -6,23 +6,31 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Unpack a nested data.table — unpack_nested_data() • uptasticsearch</title>
+<title>Unpack a nested data.table — unpack_nested_data • uptasticsearch</title>
+
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.4.0/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
-<!-- sticky kit -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
+<!-- headroom.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -30,16 +38,16 @@
 
 
 
-<meta property="og:title" content="Unpack a nested data.table — unpack_nested_data" />
 
-<meta property="og:description" content="After calling a chomp_*() function or es_search(), if
-  you had a nested array in the JSON, its corresponding column in the
-  resulting data.table is a data.frame itself (or a list of vectors). This
-  function expands that nested column out, adding its data to the original
-  data.table, and duplicating metadata down the rows as necessary.
+<meta property="og:title" content="Unpack a nested data.table — unpack_nested_data" />
+<meta property="og:description" content="After calling a chomp_* function or es_search, if
+             you had a nested array in the JSON, its corresponding column in the
+             resulting data.table is a data.frame itself (or a list of vectors). This
+             function expands that nested column out, adding its data to the original
+             data.table, and duplicating metadata down the rows as necessary.
 This is a side-effect-free function: it returns a new data.table and the
-  input data.table is unmodified." />
-<meta name="twitter:card" content="summary" />
+             input data.table is unmodified." />
+
 
 
 
@@ -53,9 +61,10 @@ This is a side-effect-free function: it returns a new data.table and the
 <![endif]-->
 
 
+
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -69,7 +78,7 @@ This is a side-effect-free function: it returns a new data.table and the
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">uptasticsearch</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0.9999</span>
       </span>
     </div>
 
@@ -77,7 +86,7 @@ This is a side-effect-free function: it returns a new data.table and the
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fa fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -100,11 +109,10 @@ This is a side-effect-free function: it returns a new data.table and the
   <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
-      
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/uptake/uptasticsearch">
-    <span class="fa fa-github fa-lg"></span>
+  <a href="https://github.com/uptake/uptasticsearch/">
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -115,30 +123,29 @@ This is a side-effect-free function: it returns a new data.table and the
 </div><!--/.navbar -->
 
       
+
       </header>
 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Unpack a nested data.table</h1>
-    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/blob/master/R/unpack_nested_data.R'><code>R/unpack_nested_data.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/uptake/uptasticsearch/tree/master/r-pkg/R/unpack_nested_data.R'><code>R/unpack_nested_data.R</code></a></small>
     <div class="hidden name"><code>unpack_nested_data.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    
-    <p>After calling a <code>chomp_*()</code> function or <code>es_search()</code>, if
-  you had a nested array in the JSON, its corresponding column in the
-  resulting data.table is a data.frame itself (or a list of vectors). This
-  function expands that nested column out, adding its data to the original
-  data.table, and duplicating metadata down the rows as necessary.</p>
+    <p>After calling a <code>chomp_*</code> function or <code>es_search</code>, if
+             you had a nested array in the JSON, its corresponding column in the
+             resulting data.table is a data.frame itself (or a list of vectors). This
+             function expands that nested column out, adding its data to the original
+             data.table, and duplicating metadata down the rows as necessary.</p>
 <p>This is a side-effect-free function: it returns a new data.table and the
-  input data.table is unmodified.</p>
-    
+             input data.table is unmodified.</p>
     </div>
 
     <pre class="usage"><span class='fu'>unpack_nested_data</span>(<span class='no'>chomped_df</span>, <span class='no'>col_to_unpack</span>)</pre>
-    
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
@@ -148,11 +155,10 @@ This is a side-effect-free function: it returns a new data.table and the
     </tr>
     <tr>
       <th>col_to_unpack</th>
-      <td><p>a character vector of length one: the column name to
-unpack</p></td>
+      <td><p>a character vector of length one: the column name to unpack</p></td>
     </tr>
     </table>
-    
+
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='co'># A sample raw result from a hits query:</span>
@@ -169,8 +175,8 @@ unpack</p></td>
 "film":"Avengers: Infinity War","pmt_amount":12.75}]}}}]'</span>
 
 <span class='co'># Chomp into a data.table</span>
-<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='chomp_hits.html'>chomp_hits</a></span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2019-09-09 21:22:30] Keeping the following nested data columns. Consider using unpack_nested_data for one:
-#&gt;  details.pastPurchases</div><div class='input'><span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
+<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='chomp_hits.html'>chomp_hits</a></span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2020-05-11 23:27:38] Keeping the following nested data columns. Consider using unpack_nested_data for one:
+#&gt;  details.pastPurchases</div><div class='input'><span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
 #&gt; 1: 2017-01-01    Austin        big_spender          chicago
 #&gt; 2: 2017-02-02     James            peasant          chicago
 #&gt; 3: 2017-03-03      Nick             critic           cannes
@@ -183,7 +189,7 @@ unpack</p></td>
 <span class='co'># Unpack by details.pastPurchases</span>
 <span class='no'>unpackedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>unpack_nested_data</span>(<span class='kw'>chomped_df</span> <span class='kw'>=</span> <span class='no'>sampleChompedDT</span>
                                  , <span class='kw'>col_to_unpack</span> <span class='kw'>=</span> <span class='st'>"details.pastPurchases"</span>)
-<span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/print'>print</a></span>(<span class='no'>unpackedDT</span>)</div><div class='output co'>#&gt;      timestamp cust_name details.cust_class details.location
+<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>unpackedDT</span>)</div><div class='output co'>#&gt;      timestamp cust_name details.cust_class details.location
 #&gt;  1: 2017-01-01    Austin        big_spender          chicago
 #&gt;  2: 2017-01-01    Austin        big_spender          chicago
 #&gt;  3: 2017-01-01    Austin        big_spender          chicago
@@ -206,16 +212,13 @@ unpack</p></td>
 #&gt;  9: Dopo la guerra (Apres la Guerre)       0.00    TRUE
 #&gt; 10:           Avengers: Infinity War      12.75      NA</div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
-            
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
+
 
       <footer>
       <div class="copyright">
@@ -223,13 +226,16 @@ unpack</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
+
       </footer>
    </div>
 
   
 
+
   </body>
 </html>
+
 

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -40,6 +40,6 @@ License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/uptasticsearch
 BugReports: https://github.com/uptake/uptasticsearch/issues
 LazyData: TRUE
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/r-pkg/_pkgdown.yml
+++ b/r-pkg/_pkgdown.yml
@@ -2,6 +2,14 @@ template:
   params:
     bootswatch: flatly
 
+repo:
+  url:
+    home: https://github.com/uptake/uptasticsearch/
+    source: https://github.com/uptake/uptasticsearch/tree/master/r-pkg/
+    issue: https://github.com/uptake/uptasticsearch/issues
+    user: https://github.com/
+
+
 reference:
   - title: Main function
     contents:


### PR DESCRIPTION
Inspired by https://github.com/microsoft/LightGBM/issues/3036.

I never noticed it, but the `Source:` links on our `pkgdown`  site are broken right now. For example, go to https://uptake.github.io/uptasticsearch/reference/es_search.html and click the link `R/es_search.R`after  `Source:`.

![image](https://user-images.githubusercontent.com/7608904/81638676-82d1d080-93df-11ea-9961-bd91e5344bfb.png)

`pkgdown` creates these links automatically if you have a GitHub link in `URL` or `BugReports` in `DESCRIPTION`. It then assumes that the R package is at the repo root (like most only-an-R-package repos). So this has probably been broken since we added Python...only a couple years 😬 

The changes in this PR were produced by upgrading to  `pkgdown`  1.5.1 and running `make gh_pages` from the root of the repo. Most of the changes are miscellaneous "`pkgdown` was updated" things, but the main change to fix the links is in `_pkgdown.yml`:

```yaml
repo:
  url:
    home: https://github.com/uptake/uptasticsearch/
    source: https://github.com/uptake/uptasticsearch/tree/master/r-pkg/
    issue: https://github.com/uptake/uptasticsearch/issues
    user: https://github.com/
```