### PR TITLE
[ci] update Elasticsearch versions in CI and docs

### DIFF
--- a/.ci/seed_es_on_travis.sh
+++ b/.ci/seed_es_on_travis.sh
@@ -50,7 +50,7 @@ case "$ES_VERSION" in
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
 
-    "6.8.8")
+    "6.8.11")
       export MAPPING_FILE=${ES6_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION.deb"
       ;;
@@ -98,6 +98,20 @@ case "$ES_VERSION" in
       ;;
 
     "7.6.2")
+      export MAPPING_FILE=${ES7_MAPPING_FILE};
+      export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
+      # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data
+      export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
+      ;;
+
+    "7.7.1")
+      export MAPPING_FILE=${ES7_MAPPING_FILE};
+      export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
+      # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data
+      export SAMPLE_DATA_FILE="${ES7_SAMPLE_DATA_FILE}"
+      ;;
+
+    "7.8.1")
       export MAPPING_FILE=${ES7_MAPPING_FILE};
       export ES_BINARY_URL="${ES5PLUS_ARCHIVE}/elasticsearch-$ES_VERSION-amd64.deb"
       # overwrite SAMPLE_DATA_FILE to use the ES7-compliant data

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       warnings_are_errors: true
       cache: packages
       env:
-        - ES_VERSION=6.8.8
+        - ES_VERSION=6.8.11
         - TASK=rpkg
     - language: r
       warnings_are_errors: true
@@ -98,6 +98,22 @@ matrix:
         - TASK=rpkg
       after_success:
         - .ci/report_to_covr.sh
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.7.1
+        - TASK=rpkg
+      after_success:
+        - .ci/report_to_covr.sh
+    - language: r
+      warnings_are_errors: true
+      cache: packages
+      env:
+        - ES_VERSION=7.8.1
+        - TASK=rpkg
+      after_success:
+        - .ci/report_to_covr.sh
     #################
     # Python builds #
     #################
@@ -129,7 +145,7 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - ES_VERSION=6.8.8
+        - ES_VERSION=6.8.11
         - TASK=pypkg
     - language: python
       python: 3.5
@@ -165,4 +181,14 @@ matrix:
       python: 3.5
       env:
         - ES_VERSION=7.6.2
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=7.7.1
+        - TASK=pypkg
+    - language: python
+      python: 3.5
+      env:
+        - ES_VERSION=7.8.1
         - TASK=pypkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,14 +89,14 @@ The set of Elasticsearch versions this project tests against changes regularly a
 
 > `uptasticsearch` may be tested against specific additional intermediate versions if bugs are found in the interaction between `uptasticsearch` and those versions
 
-So, for example, as of April 2020 that meant we tested against:
+So, for example, as of August 2020 that meant we tested against:
 
 * 1.0.0
 * 1.7.6
 * 2.4.6
 * 5.6.16
 * 6.0.1
-* 6.8.8
+* 6.8.11
 * 7.0.1
 * 7.1.1
 * 7.2.1
@@ -104,6 +104,8 @@ So, for example, as of April 2020 that meant we tested against:
 * 7.4.2
 * 7.5.2
 * 7.6.2
+* 7.7.1
+* 7.8.1
 
 You may notice that this strategy means that `uptasticsearch` is tested for backwards compatibility with Elasticsearch versions which have already reached [End-of-Life](https://www.elastic.co/support/eol). For example, support for Elasticsearch 1.7.x officially ended in January 2017. We test these old versions because we know of users whose companies still run those versions, and for whom Elasticsearch upgrades are prohibitively expensive. In general, upgrades across major versions pre-6.x [require a full cluster restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
 

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -40,13 +40,13 @@ case "${MAJOR_VERSION}" in
 6.8) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:6.8.8
+          docker.elastic.co/elasticsearch/elasticsearch:6.8.11
      MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
      ;;
-7.6) docker run -d -p 9200:9200 \
+7.8) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+          docker.elastic.co/elasticsearch/elasticsearch:7.8.1
      MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
      SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;


### PR DESCRIPTION
it's been a few months since we updated versions we test against (#209 ). This PR does that again.

* `6.8.8` --> `6.8.11`
* +`7.7.1`, +`7.8.1` (previous latest was 7.6.2)

This is the page I use to find what versions have been released: https://www.elastic.co/downloads/past-releases#elasticsearch