### PR TITLE
[R-package] remove LazyData in DESCRIPTION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -39,7 +39,6 @@ Suggests:
 License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/uptasticsearch
 BugReports: https://github.com/uptake/uptasticsearch/issues
-LazyData: TRUE
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Encoding: UTF-8


### PR DESCRIPTION
I checked the `{uptasticsearch}` CRAN check results today, to see if the package was having any issues with R 4.1.0.

https://cran.r-project.org/web/checks/check_results_uptasticsearch.html

Looks like everything is fine, but there is one new NOTE:

```text
Version: 0.4.0
Check: LazyData
Result: NOTE
     'LazyData' is specified without a 'data' directory
Flavors: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-devel-windows-x86_64, r-devel-windows-x86_64-gcc10-UCRT, r-patched-linux-x86_64, r-patched-solaris-x86, r-release-linux-x86_64, r-release-windows-ix86+x86_64
```

This PR fixes it.