### PR TITLE
[ci] update versions of ES, GitHub Actions

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,6 +22,8 @@ then
             qpdf \
         || exit -1
 
-    Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org')"
+    conda install -y -c conda-forge 'pandoc>1.12.3'
+
+    Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org'), Ncpus = parallel::detectCores())"
     cp test-data/* r-pkg/inst/testdata/
 fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -24,6 +24,6 @@ then
 
     conda install -y -c conda-forge 'pandoc>1.12.3'
 
-    Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org'), Ncpus = parallel::detectCores())"
+    Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
     cp test-data/* r-pkg/inst/testdata/
 fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,8 +22,6 @@ then
             qpdf \
         || exit -1
 
-    conda install -y -c conda-forge 'pandoc>1.12.3'
-
     Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
     cp test-data/* r-pkg/inst/testdata/
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           - task: rpkg
             es_version: 6.0.1
           - task: rpkg
+            es_version: 6.8.15
+          - task: rpkg
             es_version: 7.1.1
           - task: rpkg
             es_version: 7.2.1
@@ -40,6 +42,14 @@ jobs:
             es_version: 7.7.1
           - task: rpkg
             es_version: 7.8.1
+          - task: rpkg
+            es_version: 7.9.3
+          - task: rpkg
+            es_version: 7.10.2
+          - task: rpkg
+            es_version: 7.11.2
+          - task: rpkg
+            es_version: 7.12.1
           #--------#
           # python #
           #--------#
@@ -69,19 +79,27 @@ jobs:
             es_version: 7.7.1
           - task: pypkg
             es_version: 7.8.1
+          - task: pypkg
+            es_version: 7.9.3
+          - task: pypkg
+            es_version: 7.10.2
+          - task: pypkg
+            es_version: 7.11.2
+          - task: pypkg
+            es_version: 7.12.1
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: set up R
         if: matrix.task == 'rpkg'
         uses: r-lib/actions/setup-r@v1
         with:
-          r-version: '4.0.3'
+          r-version: '4.1.0'
       - name: set up python
         if: matrix.task == 'pypkg'
-        uses: conda-incubator/setup-miniconda@v1.7.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.7
       - name: run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,36 +20,36 @@ jobs:
           #---#
           # R #
           #---#
-          - task: rpkg
-            es_version: 1.0.3
-          - task: rpkg
-            es_version: 1.7.6
-          - task: rpkg
-            es_version: 2.4.6
-          - task: rpkg
-            es_version: 5.6.16
-          - task: rpkg
-            es_version: 6.0.1
-          - task: rpkg
-            es_version: 6.8.15
-          - task: rpkg
-            es_version: 7.1.1
-          - task: rpkg
-            es_version: 7.2.1
-          - task: rpkg
-            es_version: 7.3.2
-          - task: rpkg
-            es_version: 7.4.2
-          - task: rpkg
-            es_version: 7.5.2
-          - task: rpkg
-            es_version: 7.6.2
-          - task: rpkg
-            es_version: 7.7.1
-          - task: rpkg
-            es_version: 7.8.1
-          - task: rpkg
-            es_version: 7.9.3
+          # - task: rpkg
+          #   es_version: 1.0.3
+          # - task: rpkg
+          #   es_version: 1.7.6
+          # - task: rpkg
+          #   es_version: 2.4.6
+          # - task: rpkg
+          #   es_version: 5.6.16
+          # - task: rpkg
+          #   es_version: 6.0.1
+          # - task: rpkg
+          #   es_version: 6.8.15
+          # - task: rpkg
+          #   es_version: 7.1.1
+          # - task: rpkg
+          #   es_version: 7.2.1
+          # - task: rpkg
+          #   es_version: 7.3.2
+          # - task: rpkg
+          #   es_version: 7.4.2
+          # - task: rpkg
+          #   es_version: 7.5.2
+          # - task: rpkg
+          #   es_version: 7.6.2
+          # - task: rpkg
+          #   es_version: 7.7.1
+          # - task: rpkg
+          #   es_version: 7.8.1
+          # - task: rpkg
+          #   es_version: 7.9.3
           - task: rpkg
             es_version: 7.10.2
           - task: rpkg
@@ -59,42 +59,42 @@ jobs:
           #--------#
           # python #
           #--------#
-          - task: pypkg
-            es_version: 1.0.3
-          - task: pypkg
-            es_version: 1.7.6
-          - task: pypkg
-            es_version: 2.4.6
-          - task: pypkg
-            es_version: 5.6.16
-          - task: pypkg
-            es_version: 6.0.1
-          - task: pypkg
-            es_version: 6.8.15
-          - task: pypkg
-            es_version: 7.1.1
-          - task: pypkg
-            es_version: 7.2.1
-          - task: pypkg
-            es_version: 7.3.2
-          - task: pypkg
-            es_version: 7.4.2
-          - task: pypkg
-            es_version: 7.5.2
-          - task: pypkg
-            es_version: 7.6.2
-          - task: pypkg
-            es_version: 7.7.1
-          - task: pypkg
-            es_version: 7.8.1
-          - task: pypkg
-            es_version: 7.9.3
-          - task: pypkg
-            es_version: 7.10.2
-          - task: pypkg
-            es_version: 7.11.2
-          - task: pypkg
-            es_version: 7.12.1
+          # - task: pypkg
+          #   es_version: 1.0.3
+          # - task: pypkg
+          #   es_version: 1.7.6
+          # - task: pypkg
+          #   es_version: 2.4.6
+          # - task: pypkg
+          #   es_version: 5.6.16
+          # - task: pypkg
+          #   es_version: 6.0.1
+          # - task: pypkg
+          #   es_version: 6.8.15
+          # - task: pypkg
+          #   es_version: 7.1.1
+          # - task: pypkg
+          #   es_version: 7.2.1
+          # - task: pypkg
+          #   es_version: 7.3.2
+          # - task: pypkg
+          #   es_version: 7.4.2
+          # - task: pypkg
+          #   es_version: 7.5.2
+          # - task: pypkg
+          #   es_version: 7.6.2
+          # - task: pypkg
+          #   es_version: 7.7.1
+          # - task: pypkg
+          #   es_version: 7.8.1
+          # - task: pypkg
+          #   es_version: 7.9.3
+          # - task: pypkg
+          #   es_version: 7.10.2
+          # - task: pypkg
+          #   es_version: 7.11.2
+          # - task: pypkg
+          #   es_version: 7.12.1
     steps:
       - name: checkout repository
         uses: actions/checkout@v2
@@ -106,7 +106,6 @@ jobs:
         with:
           r-version: '4.1.0'
       - name: set up python
-        if: matrix.task == 'pypkg'
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
         uses: r-lib/actions/setup-r@v1
         with:
           r-version: '4.1.0'
+      - name: set up pandoc
+        if: matrix.task == 'rpkg'
+        uses: r-lib/actions/setup-pandoc@v1
       - name: set up python
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,36 +20,36 @@ jobs:
           #---#
           # R #
           #---#
-          # - task: rpkg
-          #   es_version: 1.0.3
-          # - task: rpkg
-          #   es_version: 1.7.6
-          # - task: rpkg
-          #   es_version: 2.4.6
-          # - task: rpkg
-          #   es_version: 5.6.16
-          # - task: rpkg
-          #   es_version: 6.0.1
-          # - task: rpkg
-          #   es_version: 6.8.15
-          # - task: rpkg
-          #   es_version: 7.1.1
-          # - task: rpkg
-          #   es_version: 7.2.1
-          # - task: rpkg
-          #   es_version: 7.3.2
-          # - task: rpkg
-          #   es_version: 7.4.2
-          # - task: rpkg
-          #   es_version: 7.5.2
-          # - task: rpkg
-          #   es_version: 7.6.2
-          # - task: rpkg
-          #   es_version: 7.7.1
-          # - task: rpkg
-          #   es_version: 7.8.1
-          # - task: rpkg
-          #   es_version: 7.9.3
+          - task: rpkg
+            es_version: 1.0.3
+          - task: rpkg
+            es_version: 1.7.6
+          - task: rpkg
+            es_version: 2.4.6
+          - task: rpkg
+            es_version: 5.6.16
+          - task: rpkg
+            es_version: 6.0.1
+          - task: rpkg
+            es_version: 6.8.15
+          - task: rpkg
+            es_version: 7.1.1
+          - task: rpkg
+            es_version: 7.2.1
+          - task: rpkg
+            es_version: 7.3.2
+          - task: rpkg
+            es_version: 7.4.2
+          - task: rpkg
+            es_version: 7.5.2
+          - task: rpkg
+            es_version: 7.6.2
+          - task: rpkg
+            es_version: 7.7.1
+          - task: rpkg
+            es_version: 7.8.1
+          - task: rpkg
+            es_version: 7.9.3
           - task: rpkg
             es_version: 7.10.2
           - task: rpkg
@@ -59,42 +59,42 @@ jobs:
           #--------#
           # python #
           #--------#
-          # - task: pypkg
-          #   es_version: 1.0.3
-          # - task: pypkg
-          #   es_version: 1.7.6
-          # - task: pypkg
-          #   es_version: 2.4.6
-          # - task: pypkg
-          #   es_version: 5.6.16
-          # - task: pypkg
-          #   es_version: 6.0.1
-          # - task: pypkg
-          #   es_version: 6.8.15
-          # - task: pypkg
-          #   es_version: 7.1.1
-          # - task: pypkg
-          #   es_version: 7.2.1
-          # - task: pypkg
-          #   es_version: 7.3.2
-          # - task: pypkg
-          #   es_version: 7.4.2
-          # - task: pypkg
-          #   es_version: 7.5.2
-          # - task: pypkg
-          #   es_version: 7.6.2
-          # - task: pypkg
-          #   es_version: 7.7.1
-          # - task: pypkg
-          #   es_version: 7.8.1
-          # - task: pypkg
-          #   es_version: 7.9.3
-          # - task: pypkg
-          #   es_version: 7.10.2
-          # - task: pypkg
-          #   es_version: 7.11.2
-          # - task: pypkg
-          #   es_version: 7.12.1
+          - task: pypkg
+            es_version: 1.0.3
+          - task: pypkg
+            es_version: 1.7.6
+          - task: pypkg
+            es_version: 2.4.6
+          - task: pypkg
+            es_version: 5.6.16
+          - task: pypkg
+            es_version: 6.0.1
+          - task: pypkg
+            es_version: 6.8.15
+          - task: pypkg
+            es_version: 7.1.1
+          - task: pypkg
+            es_version: 7.2.1
+          - task: pypkg
+            es_version: 7.3.2
+          - task: pypkg
+            es_version: 7.4.2
+          - task: pypkg
+            es_version: 7.5.2
+          - task: pypkg
+            es_version: 7.6.2
+          - task: pypkg
+            es_version: 7.7.1
+          - task: pypkg
+            es_version: 7.8.1
+          - task: pypkg
+            es_version: 7.9.3
+          - task: pypkg
+            es_version: 7.10.2
+          - task: pypkg
+            es_version: 7.11.2
+          - task: pypkg
+            es_version: 7.12.1
     steps:
       - name: checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           - task: pypkg
             es_version: 6.0.1
           - task: pypkg
+            es_version: 6.8.15
+          - task: pypkg
             es_version: 7.1.1
           - task: pypkg
             es_version: 7.2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ So, for example, as of September 2020 that meant we tested against:
 * 2.4.6
 * 5.6.16
 * 6.0.1
-* 6.8.11
+* 6.8.15
 * 7.0.1
 * 7.1.1
 * 7.2.1
@@ -104,6 +104,10 @@ So, for example, as of September 2020 that meant we tested against:
 * 7.6.2
 * 7.7.1
 * 7.8.1
+* 7.9.3
+* 7.10.2
+* 7.11.2
+* 7.12.1
 
 You may notice that this strategy means that `uptasticsearch` is tested for backwards compatibility with Elasticsearch versions which have already reached [End-of-Life](https://www.elastic.co/support/eol). For example, support for Elasticsearch 1.7.x officially ended in January 2017. We test these old versions because we know of users whose companies still run those versions, and for whom Elasticsearch upgrades are prohibitively expensive. In general, upgrades across major versions pre-6.x [require a full cluster restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
 
@@ -115,7 +119,7 @@ To run the code below, you will need [Docker](https://www.docker.com/). Note tha
 
 ```shell
 # Start up Elasticsearch on localhost:9200 and seed it with data
-./setup_local.sh 7.8.1
+./setup_local.sh 7.12.1
 
 # Run tests
 make test_r

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -36,7 +36,7 @@ case "${ES_VERSION}" in
           docker.elastic.co/elasticsearch/elasticsearch:6.0.1
      MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
     ;;
-6.8.11) docker run -d -p 9200:9200 \
+6.8.15) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
           docker.elastic.co/elasticsearch/elasticsearch:6.8.11
@@ -102,6 +102,34 @@ case "${ES_VERSION}" in
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
           docker.elastic.co/elasticsearch/elasticsearch:7.8.1
+     MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
+     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
+    ;;
+7.9.3) docker run -d -p 9200:9200 \
+          -e "discovery.type=single-node" \
+          -e "xpack.security.enabled=false" \
+          docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+     MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
+     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
+    ;;
+7.10.2) docker run -d -p 9200:9200 \
+          -e "discovery.type=single-node" \
+          -e "xpack.security.enabled=false" \
+          docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+     MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
+     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
+    ;;
+7.11.2) docker run -d -p 9200:9200 \
+          -e "discovery.type=single-node" \
+          -e "xpack.security.enabled=false" \
+          docker.elastic.co/elasticsearch/elasticsearch:7.12.2
+     MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
+     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
+    ;;
+7.12.1) docker run -d -p 9200:9200 \
+          -e "discovery.type=single-node" \
+          -e "xpack.security.enabled=false" \
+          docker.elastic.co/elasticsearch/elasticsearch:7.12.1
      MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
      SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -122,7 +122,7 @@ case "${ES_VERSION}" in
 7.11.2) docker run -d -p 9200:9200 \
           -e "discovery.type=single-node" \
           -e "xpack.security.enabled=false" \
-          docker.elastic.co/elasticsearch/elasticsearch:7.12.2
+          docker.elastic.co/elasticsearch/elasticsearch:7.11.2
      MAPPING_FILE=$(pwd)/test-data/es7_shakespeare_mapping.json
      SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;


### PR DESCRIPTION
It's been about 7 months since the last commit in this project (#217). This PR updates a few versions of things in CI as standard maintenance.

* Elasticsearch versions (based on https://www.elastic.co/downloads/past-releases)
* versions of all GitHub Actions used
* version of R (4.0.3 --> 4.1.0)