### PR TITLE
[R-package] switch to SummaryReporter, remove context(), other testthat changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,8 @@
 *-Ex.R
 
 # Output files from R CMD build
-/*.tar.gz
-
-# Output files from R CMD check
-/*.Rcheck/
+*.tar.gz
+*.Rcheck/
 
 # RStudio files
 *.Rproj

--- a/r-pkg/tests/testthat.R
+++ b/r-pkg/tests/testthat.R
@@ -1,10 +1,9 @@
-# Note that you would never run this file directly. This is used by tools::testInstallPackages()
-# and other packages like covr.
-
-# This line ensures that R CMD check can run tests.
-# See https://github.com/hadley/testthat/issues/144
-Sys.setenv("R_TESTS" = "")
-
+library(testthat)
 library(uptasticsearch)
 
-testthat::test_check('uptasticsearch')
+testthat::test_check(
+    package = "uptasticsearch"
+    , stop_on_failure = TRUE
+    , stop_on_warning = FALSE
+    , reporter = testthat::SummaryReporter$new()
+)

--- a/r-pkg/tests/testthat/test-chomp_aggs.R
+++ b/r-pkg/tests/testthat/test-chomp_aggs.R
@@ -8,8 +8,6 @@ if (!identical(loggerOptions, list())){
 }
 futile.logger::flog.threshold(0)
 
-context("chomp_aggs")
-
 # Works with 1 variable from an R string
 test_that(
     "chomp_aggs should work from an R string with one grouping variable", {
@@ -609,4 +607,3 @@ test_that("chomp_aggs should work for an empty terms result", {
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())

--- a/r-pkg/tests/testthat/test-chomp_hits.R
+++ b/r-pkg/tests/testthat/test-chomp_hits.R
@@ -8,8 +8,6 @@ if (!identical(loggerOptions, list())){
 }
 futile.logger::flog.threshold(0)
 
-context("chomp_hits")
-
 # This is effectively a test of running elastic::Search(raw = TRUE) and passing it through chomp_hits()
 test_that("chomp_hits should work from a one-element character vector",
           {jsonString <- '{"took": 54, "timed_out": false, "_shards": {"total": 16,"successful": 16, "failed": 0},
@@ -127,4 +125,3 @@ test_that("chomp_hits should warn and delete if the resulting data is nested wit
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())

--- a/r-pkg/tests/testthat/test-es_search.R
+++ b/r-pkg/tests/testthat/test-es_search.R
@@ -8,8 +8,6 @@ if (!identical(loggerOptions, list())){
 }
 futile.logger::flog.threshold(0)
 
-context("es_search")
-
 # Should reject NULL index
 test_that("es_search should reject NULL index", {
     expect_error({
@@ -130,4 +128,3 @@ test_that(".major_version should correctly parse semver version strings", {
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())

--- a/r-pkg/tests/testthat/test-get_fields.R
+++ b/r-pkg/tests/testthat/test-get_fields.R
@@ -1,5 +1,3 @@
-context("get_fields")
-
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
 if (!identical(loggerOptions, list())){
@@ -115,4 +113,3 @@ futile.logger::flog.threshold(0)
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -1,5 +1,3 @@
-context("Elasticsearch integration tests")
-
 # tests in this file are run automatically in CI and require
 # an actual Elasticsearch cluster to be up and running. For details,
 # see: https://github.com/uptake/uptasticsearch/blob/main/.github/workflows/ci.yml
@@ -476,4 +474,3 @@ futile.logger::flog.threshold(0)
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())

--- a/r-pkg/tests/testthat/test-parse_date_time.R
+++ b/r-pkg/tests/testthat/test-parse_date_time.R
@@ -7,9 +7,6 @@ if (!identical(loggerOptions, list())){
 }
 futile.logger::flog.threshold(0)
 
-context("parse_date_time")
-
-
 # Correctly adjusts UTC date-times
 test_that("parse_date_time should transform the indicated date_cols to POSIXct with timezone UTC if they're given in UTC", {
     testDT <- data.table::data.table(
@@ -176,4 +173,3 @@ test_that("parse_date_time should leave the original DT unchanged", {
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())

--- a/r-pkg/tests/testthat/test-unpack_nested_data.R
+++ b/r-pkg/tests/testthat/test-unpack_nested_data.R
@@ -8,8 +8,6 @@ if (!identical(loggerOptions, list())){
 }
 futile.logger::flog.threshold(0)
 
-context("Elasticsearch result-parsing functions")
-
 #--- unpack_nested_data
 
     # Should work with result of chomp_hits
@@ -112,4 +110,3 @@ context("Elasticsearch result-parsing functions")
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
-rm(list = ls())


### PR DESCRIPTION
Contributes to #223

Starts some cleanup of the project's `{testthat}` code, adapting to things that have changed in that library of the last few years.

* removes `context()`... unnecessary now that `{testthat}` infers it from the test file name
  - ref: https://github.com/microsoft/LightGBM/pull/4915
* stops unsetting `R_TESTS`
  - *the reasons behind https://github.com/hadley/testthat/issues/144 no longer apply here*
* removes `rm(list = ls())` at the end of every test
   - *these are not necessary any more, and could be a source of issues in the future if they interact in bad ways with the test collection and loading mechanisms used by `{testthat}`
* switches to `testthat::SummaryReporter`, to get nice output like this:

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/8dff5b2b-e558-4851-aa58-452e8f339602" />
