### PR TITLE
[ci] re-enable all {lintr} linters

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -29,17 +29,15 @@ interactive_text <- paste0(
 )
 
 LINTERS_TO_USE <- list(
-    # "absolute_path"          = lintr::absolute_path_linter()
-    "assignment"           = lintr::assignment_linter()
-    # , "closed_curly"         = lintr::closed_curly_linter()
+    "absolute_path"          = lintr::absolute_path_linter()
+    , "assignment"           = lintr::assignment_linter()
+    , "braces"               = lintr::brace_linter()
     , "commas"               = lintr::commas_linter()
     , "equals_na"            = lintr::equals_na_linter()
     , "function_left"        = lintr::function_left_parentheses_linter()
     , "infix_spaces"         = lintr::infix_spaces_linter()
-    , "no_tabs"              = lintr::no_tab_linter()
-    # , "non_portable_path"    = lintr::nonportable_path_linter()
-    # , "open_curly"           = lintr::open_curly_linter()
-    , "semicolon"            = lintr::semicolon_terminator_linter()
+    , "non_portable_path"    = lintr::nonportable_path_linter()
+    , "semicolon"            = lintr::semicolon_linter()
     , "seq"                  = lintr::seq_linter()
     , "spaces_inside"        = lintr::spaces_inside_linter()
     , "spaces_left_parens"   = lintr::spaces_left_parentheses_linter()
@@ -72,7 +70,8 @@ LINTERS_TO_USE <- list(
             , "??" = interactive_text
         )
     )
-    , "unneeded_concatenation" = lintr::unneeded_concatenation_linter()
+    , "unnecessary_concatenation" = lintr::unnecessary_concatenation_linter()
+    , "whitespace"                = lintr::whitespace_linter()
 )
 
 cat(sprintf("Found %i R files to lint\n", length(FILES_TO_LINT)))

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -16,6 +16,7 @@ sudo apt-get install \
     texlive-latex-recommended \
     texlive-fonts-recommended \
     texlive-fonts-extra \
+    tidy \
     qpdf
 
 Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - main
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # parallelize compilation (extra important for Linux, where CRAN doesn't supply pre-compiled binaries)
+  MAKEFLAGS: "-j4"
+
 jobs:
   test:
     name: test (ES ${{ matrix.es_version }})

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -84,10 +84,10 @@ es_search <- function(es_host
                       , break_on_duplicates = TRUE
                       , ignore_scroll_restriction = FALSE
                       , intermediates_dir = getwd()
-){
+) {
 
     # Check if this is an aggs or straight-up search query
-    if (!assertthat::is.string(query_body)){
+    if (!assertthat::is.string(query_body)) {
         msg <- sprintf(paste0("query_body should be a single string. ",
                               "You gave an object of length %s")
                        , length(query_body))
@@ -95,7 +95,7 @@ es_search <- function(es_host
     }
 
     # prevent NULL index
-    if (is.null(es_index)){
+    if (is.null(es_index)) {
         msg <- paste0(
             "You passed NULL to es_index. This is not supported. If you want to "
             , "search across all indices, use es_index = '_all'."
@@ -104,7 +104,7 @@ es_search <- function(es_host
     }
 
     # assign 1 core by default, if the number of cores is NA
-    if (is.na(n_cores) || !assertthat::is.count(n_cores)){
+    if (is.na(n_cores) || !assertthat::is.count(n_cores)) {
       msg <- "detectCores() returned NA. Assigning number of cores to be 1."
       log_warn(msg)
       n_cores <- 1
@@ -132,7 +132,7 @@ es_search <- function(es_host
     )
 
     # Aggregation Request
-    if (grepl('aggs', query_body)){
+    if (grepl('aggs', query_body)) {
 
         # Let them know
         msg <- paste0("es_search detected that this is an aggs request ",
@@ -235,13 +235,13 @@ es_search <- function(es_host
                      , break_on_duplicates
                      , ignore_scroll_restriction
                      , intermediates_dir
-){
+) {
 
     # Check es_host
     es_host <- .ValidateAndFormatHost(es_host)
 
     # Protect against costly scroll settings
-    if (.ConvertToSec(scroll) > 60 * 60 & !ignore_scroll_restriction){
+    if (.ConvertToSec(scroll) > 60 * 60 & !ignore_scroll_restriction) {
         msg <- paste0("By default, this function does not permit scroll requests ",
                       "which keep the scroll context open for more than one hour.\n",
                       "\nYou provided the following value to 'scroll': ",
@@ -502,7 +502,9 @@ es_search <- function(es_host
 
         # Break if we got nothing
         hitsInThisPage <- length(resultList[["hits"]][["hits"]])
-        if (hitsInThisPage == 0){break}
+        if (hitsInThisPage == 0){
+            break
+        }
 
         # If we have more to pull, get the new scroll_id
         # NOTE: http://stackoverflow.com/questions/25453872/why-does-this-elasticsearch-scan-and-scroll-keep-returning-the-same-scroll-id
@@ -532,12 +534,12 @@ es_search <- function(es_host
 .new_scroll_request <- function(es_host, scroll, scroll_id){
 
     # Set up scroll_url
-    scroll_url <- paste0(es_host, "/_search/scroll")
+    scroll_url <- paste0(es_host, "/_search/scroll")  # nolint[absolute_path,non_portable_path]
 
     # Get the next page
     result <- httr::RETRY(
         verb = "POST"
-        , httr::add_headers(c('Content-Type' = 'application/json'))
+        , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
         , url = scroll_url
         , body = sprintf('{"scroll": "%s", "scroll_id": "%s"}', scroll, scroll_id)
     )
@@ -556,7 +558,7 @@ es_search <- function(es_host
     # Get the next page
     result <- httr::RETRY(
         verb = "POST"
-        , httr::add_headers(c('Content-Type' = 'application/json'))
+        , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
         , url = scroll_url
         , body = scroll_id
     )
@@ -631,7 +633,7 @@ es_search <- function(es_host
     log_info("Checking Elasticsearch version...")
     result <- httr::RETRY(
         verb = "GET"
-        , httr::add_headers(c('Content-Type' = 'application/json'))
+        , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
         , url = es_host
     )
     httr::stop_for_status(result)
@@ -716,7 +718,7 @@ es_search <- function(es_host
     # Make request
     result <- httr::RETRY(
         verb = "POST"
-        , httr::add_headers(c('Content-Type' = 'application/json'))
+        , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
         , url = reqURL
         , body = query_body
     )

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -300,7 +300,7 @@ es_search <- function(es_host
     firstResult <- jsonlite::fromJSON(firstResultJSON, simplifyVector = FALSE)
 
     major_version <- .get_es_version(es_host)
-    if (as.integer(major_version) > 6){
+    if (as.integer(major_version) > 6) {
       hits_to_pull <- min(firstResult[["hits"]][["total"]][["value"]], max_hits)
     } else {
       hits_to_pull <- min(firstResult[["hits"]][["total"]], max_hits)
@@ -366,7 +366,7 @@ es_search <- function(es_host
 
     # If the user requested 1 core, just run single-threaded.
     # Not worth the overhead of setting up the cluster.
-    if (n_cores == 1){
+    if (n_cores == 1) {
         outDT <- data.table::rbindlist(
             lapply(tempFiles
                    , FUN = .read_and_parse_tempfile
@@ -377,7 +377,7 @@ es_search <- function(es_host
     } else {
 
         # Set up cluster. Note that Fork clusters cannot be used on Windows
-        if (grepl('windows', Sys.info()[['sysname']], ignore.case = TRUE)){
+        if (grepl('windows', Sys.info()[['sysname']], ignore.case = TRUE)) {
             cl <- parallel::makePSOCKcluster(names = n_cores)
         } else {
             cl <- parallel::makeForkCluster(nnodes = n_cores)
@@ -408,7 +408,7 @@ es_search <- function(es_host
     outDT <- unique(outDT, by = "_id")
 
     # Check we got the number of unique records we expected
-    if (nrow(outDT) < hits_to_pull && break_on_duplicates){
+    if (nrow(outDT) < hits_to_pull && break_on_duplicates) {
         msg <- paste0("Some data was lost during parallel pulling + writing to disk.",
                       " Expected ", hits_to_pull, " records but only got ", nrow(outDT), ".",
                       " File collisions are unlikely but possible with this function.",
@@ -428,7 +428,7 @@ es_search <- function(es_host
 # [params] keep_nested_data_cols Boolean flag indicating whether or not to
 #          preserver columns that could not be flattened in the result
 #          data.table (i.e. live as arrays with duplicate keys in the result from Elasticsearch)
-.read_and_parse_tempfile <- function(file_name, keep_nested_data_cols){
+.read_and_parse_tempfile <- function(file_name, keep_nested_data_cols) {
 
     # NOTE: namespacing uptasticsearch here to prevent against weirdness
     #       when distributing this function to multiple workers in a cluster
@@ -472,7 +472,7 @@ es_search <- function(es_host
                             , scroll
                             , hits_pulled
                             , hits_to_pull
-){
+) {
 
     # Note that the old scrolling strategy was deprecated in Elasticsearch 5.x and
     # officially dropped in Elasticsearch 6.x. Need to grab the correct method here
@@ -486,7 +486,7 @@ es_search <- function(es_host
         , .new_scroll_request
     )
 
-    while (hits_pulled < max_hits){
+    while (hits_pulled < max_hits) {
 
         # Grab a page of hits, break if we got back an error.
         result <- scrolling_request(
@@ -502,7 +502,7 @@ es_search <- function(es_host
 
         # Break if we got nothing
         hitsInThisPage <- length(resultList[["hits"]][["hits"]])
-        if (hitsInThisPage == 0){
+        if (hitsInThisPage == 0) {
             break
         }
 
@@ -531,7 +531,7 @@ es_search <- function(es_host
 # [description] Make a scrolling request and return the result
 # [references] https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html
 #' @importFrom httr add_headers RETRY
-.new_scroll_request <- function(es_host, scroll, scroll_id){
+.new_scroll_request <- function(es_host, scroll, scroll_id) {
 
     # Set up scroll_url
     scroll_url <- paste0(es_host, "/_search/scroll")  # nolint[absolute_path,non_portable_path]
@@ -550,7 +550,7 @@ es_search <- function(es_host
 # [name] .legacy_scroll_request
 # [description] Make a scrolling request and return the result
 #' @importFrom httr add_headers RETRY
-.legacy_scroll_request <- function(es_host, scroll, scroll_id){
+.legacy_scroll_request <- function(es_host, scroll, scroll_id) {
 
     # Set up scroll_url
     scroll_url <- paste0(es_host, "/_search/scroll?scroll=", scroll)
@@ -569,17 +569,17 @@ es_search <- function(es_host
 # [title] Check that a string is a valid host for an Elasticsearch cluster
 # [param] A string of the form [transfer_protocol][hostname]:[port].
 #         If any of those elements are missing, some defaults will be added
-.ValidateAndFormatHost <- function(es_host){
+.ValidateAndFormatHost <- function(es_host) {
 
     # es_host is a string
-    if (! is.character(es_host)){
+    if (! is.character(es_host)) {
         msg <- paste0("es_host should be a string. You gave an object of type"
                       , paste0(class(es_host), collapse = '/'))
         log_fatal(msg)
     }
 
     # es_host is length 1
-    if (! length(es_host) == 1){
+    if (! length(es_host) == 1) {
         msg <- paste0("es_host should be length 1."
                       , " You provided an object of length "
                       , length(es_host))
@@ -588,14 +588,14 @@ es_search <- function(es_host
 
     # Does not end in a slash
     trailingSlashPattern <- '/+$'
-    if (grepl(trailingSlashPattern, es_host)){
+    if (grepl(trailingSlashPattern, es_host)) {
         # Remove it
         es_host <- gsub('/+$', '', es_host)
     }
 
     # es_host has a port number
     portPattern <- ':[0-9]+$'
-    if (! grepl(portPattern, es_host) == 1){
+    if (! grepl(portPattern, es_host) == 1) {
         msg <- paste0('No port found in es_host! es_host should be a string of the'
                       , 'form [transfer_protocol][hostname]:[port]). for '
                       , 'example: "http://myindex.mysite.com:9200"')
@@ -604,7 +604,7 @@ es_search <- function(es_host
 
     # es_host has a valid transfer protocol
     protocolPattern <- '^[A-Za-z]+://'
-    if (! grepl(protocolPattern, es_host) == 1){
+    if (! grepl(protocolPattern, es_host) == 1) {
         msg <- paste0('You did not provide a transfer protocol (e.g. http://) with es_host.'
                       , 'Assuming http://...')
         log_warn(msg)
@@ -627,7 +627,7 @@ es_search <- function(es_host
 # [param] es_host A string identifying an Elasticsearch host. This should be of the form
 #         [transfer_protocol][hostname]:[port]. For example, 'http://myindex.thing.com:9200'.
 #' @importFrom httr content RETRY stop_for_status
-.get_es_version <- function(es_host){
+.get_es_version <- function(es_host) {
 
     # Hit the cluster root to get metadata
     log_info("Checking Elasticsearch version...")
@@ -654,7 +654,7 @@ es_search <- function(es_host
 # [description] Get major version from a dot-delimited version string
 # [param] version_string A dot-delimited version string
 #' @importFrom stringr str_split
-.major_version <- function(version_string){
+.major_version <- function(version_string) {
     components <- stringr::str_split(version_string, "\\.")[[1]]
     return(components[1])
 }
@@ -704,14 +704,14 @@ es_search <- function(es_host
                           , es_index
                           , trailing_args = NULL
                           , query_body
-){
+) {
 
     # Input checking
     es_host <- .ValidateAndFormatHost(es_host)
 
     # Build URL
     reqURL <- paste0(es_host, '/', es_index, '/_search')
-    if (!is.null(trailing_args)){
+    if (!is.null(trailing_args)) {
         reqURL <- paste0(reqURL, '?', paste0(trailing_args, collapse = "&"))
     }
 

--- a/r-pkg/R/get_fields.R
+++ b/r-pkg/R/get_fields.R
@@ -52,7 +52,7 @@ get_fields <- function(es_host
         log_warn(sprintf(
             paste0(
                 "You are running Elasticsearch version '%s.x'. _all is not supported in this version."
-                , " Pulling all indices with 'POST /_cat/indices' for you."
+                , " Pulling all indices with 'POST /_cat/indices' for you."  # nolint[non_portable_path]
             )
             , major_version
         ))
@@ -87,7 +87,7 @@ get_fields <- function(es_host
     result <- httr::RETRY(
         verb = "GET"
         , url = es_url
-        , httr::add_headers(c('Content-Type' = 'application/json'))
+        , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
     )
     httr::stop_for_status(result)
     resultContent <- httr::content(result, as = 'parsed')
@@ -106,7 +106,7 @@ get_fields <- function(es_host
                         index = index_name
                         , type = NA_character_
                         , field = names(props)
-                        , data_type = sapply(props, function(x){x$type})
+                        , data_type = sapply(props, function(x){x$type})  # nolint[open_curly]
                     )
                     return(thisIndexDT)
                 }
@@ -199,13 +199,13 @@ get_fields <- function(es_host
 .get_aliases <- function(es_host) {
 
     # construct the url to the alias endpoint
-    url <- paste0(es_host, '/_cat/aliases')
+    url <- paste0(es_host, '/_cat/aliases')  # nolint[absolute_path, non_portable_path]
 
     # make the request
     result <- httr::RETRY(
         verb = "GET"
         , url = url
-        , httr::add_headers(c('Content-Type' = 'application/json'))
+        , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
     )
     httr::stop_for_status(result)
     resultContent <- httr::content(result, as = 'text')

--- a/r-pkg/R/get_fields.R
+++ b/r-pkg/R/get_fields.R
@@ -36,7 +36,7 @@ get_fields <- function(es_host
     # are NULL, create an empty string
     indices <- paste(es_indices, collapse = ',')
 
-    if (nchar(indices) == 0){
+    if (nchar(indices) == 0) {
         msg <- paste("get_fields must be passed a valid es_indices."
                      , "You provided", paste(es_indices, collapse = ', ')
                      , 'which resulted in an empty string')
@@ -48,7 +48,7 @@ get_fields <- function(es_host
     )
 
     # The use of "_all" to indicate "all indices" was removed in Elasticsearch 7.
-    if (as.integer(major_version) > 6 && indices == "_all"){
+    if (as.integer(major_version) > 6 && indices == "_all") {
         log_warn(sprintf(
             paste0(
                 "You are running Elasticsearch version '%s.x'. _all is not supported in this version."
@@ -93,20 +93,20 @@ get_fields <- function(es_host
     resultContent <- httr::content(result, as = 'parsed')
 
     ######################### flatten the result ##############################
-    if (as.integer(major_version) > 6){
+    if (as.integer(major_version) > 6) {
         # As of Elasticsearch 7, indices cannot contain multiple types so the concept of
         # a "type" in a mapping is irrelevant. Maintaining the field here
         # for backwards compatibility of this function.
         mappingDT <- data.table::rbindlist(
             l = lapply(
                 X = names(resultContent)
-                , FUN = function(index_name){
+                , FUN = function(index_name) {
                     props <- resultContent[[index_name]][["mappings"]][["properties"]]
                     thisIndexDT <- data.table::data.table(
                         index = index_name
                         , type = NA_character_
                         , field = names(props)
-                        , data_type = sapply(props, function(x){x$type})  # nolint[open_curly]
+                        , data_type = sapply(props, function(x) {x$type})  # nolint[open_curly]
                     )
                     return(thisIndexDT)
                 }
@@ -130,7 +130,7 @@ get_fields <- function(es_host
             purrr::map2(
                 .x = rawAliasDT[["index"]]
                 , .y = rawAliasDT[["alias"]]
-                , .f = function(idx_name, alias_name, mappingDT){
+                , .f = function(idx_name, alias_name, mappingDT) {
                     tmpDT <- mappingDT[index == idx_name]
                     tmpDT[, index := alias_name]
                     return(tmpDT)
@@ -237,7 +237,7 @@ get_fields <- function(es_host
 # [alias_string] A string returned by the alias API with index and alias name
 #' @importFrom data.table as.data.table
 #' @importFrom jsonlite fromJSON
-.process_legacy_alias <- function(alias_string){
+.process_legacy_alias <- function(alias_string) {
     aliasDT <- data.table::as.data.table(
         jsonlite::fromJSON(
             alias_string

--- a/r-pkg/R/parse_date_time.R
+++ b/r-pkg/R/parse_date_time.R
@@ -37,10 +37,10 @@
 parse_date_time <- function(input_df
                             , date_cols
                             , assume_tz = "UTC"
-){
+) {
 
     # Break if input_df isn't actually a data.table
-    if (!data.table::is.data.table(input_df)){
+    if (!data.table::is.data.table(input_df)) {
         msg <- paste("parse_date_time expects to receive a data.table object."
                      , "You provided an object of class"
                      , paste(class(input_df), collapse = ", ")
@@ -57,7 +57,7 @@ parse_date_time <- function(input_df
     }
 
     # Break if any of the date_cols are not actually in this DT
-    if (!all(date_cols %in% names(input_df))){
+    if (!all(date_cols %in% names(input_df))) {
         not_there <- date_cols[!(date_cols %in% names(input_df))]
         msg <- paste("The following columns, which you passed to date_cols,",
                      "do not actually exist in input_df:",
@@ -107,7 +107,7 @@ parse_date_time <- function(input_df
     # nolint end
 
     # Parse dates, return POSIXct UTC dates
-    for (dateCol in date_cols){
+    for (dateCol in date_cols) {
 
         # Grab this vector to work on
         dateVec <- outDT[[dateCol]]
@@ -128,7 +128,7 @@ parse_date_time <- function(input_df
         dateTimes <- purrr::map2(
             dateTimes
             , timeZones
-            , function(dateTime, timeZone){
+            , function(dateTime, timeZone) {
                 return(as.POSIXct(dateTime, tz = timeZone))
             }
         )

--- a/r-pkg/R/parse_date_time.R
+++ b/r-pkg/R/parse_date_time.R
@@ -78,6 +78,7 @@ parse_date_time <- function(input_df
     # Military (one-letter) times:
     # Mapping UTC to etc --> https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     tzHash <- vector("character")
+    # nolint start
     tzHash["A"] <-  "Etc/GMT-1" # UTC +1
     tzHash["B"] <-  "Etc/GMT-2" # UTC +2
     tzHash["C"] <-  "Etc/GMT-3" # UTC +3
@@ -103,6 +104,7 @@ parse_date_time <- function(input_df
     tzHash["X"] <-  "Etc/GMT+11" # UTC -11
     tzHash["Y"] <-  "Etc/GMT+12" # UTC -12
     tzHash["Z"] <-  "UTC" # UTC
+    # nolint end
 
     # Parse dates, return POSIXct UTC dates
     for (dateCol in date_cols){
@@ -111,8 +113,11 @@ parse_date_time <- function(input_df
         dateVec <- outDT[[dateCol]]
 
         # Parse out timestamps and military timezone strings
-        dateTimes <- paste0(stringr::str_extract(dateVec, "^\\d{4}-\\d{2}-\\d{2}"), " ",
-                            stringr::str_extract(dateVec, "\\d{2}:\\d{2}:\\d{2}"))
+        dateTimes <- paste0(
+            stringr::str_extract(dateVec, "^\\d{4}-\\d{2}-\\d{2}")  # nolint[non_portable_path]
+            , " "
+            , stringr::str_extract(dateVec, "\\d{2}:\\d{2}:\\d{2}")
+        )
         tzKeys <- stringr::str_extract(dateVec, "[A-Za-z]{1}$")
 
         # Grab a vector of timezones
@@ -123,7 +128,9 @@ parse_date_time <- function(input_df
         dateTimes <- purrr::map2(
             dateTimes
             , timeZones
-            , function(dateTime, timeZone){as.POSIXct(dateTime, tz = timeZone)}
+            , function(dateTime, timeZone){
+                return(as.POSIXct(dateTime, tz = timeZone))
+            }
         )
 
         utcDates <- as.POSIXct.numeric(

--- a/r-pkg/tests/testthat/test-chomp_aggs.R
+++ b/r-pkg/tests/testthat/test-chomp_aggs.R
@@ -1,7 +1,7 @@
 
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO

--- a/r-pkg/tests/testthat/test-chomp_aggs.R
+++ b/r-pkg/tests/testthat/test-chomp_aggs.R
@@ -9,8 +9,7 @@ if (!identical(loggerOptions, list())){
 futile.logger::flog.threshold(0)
 
 # Works with 1 variable from an R string
-test_that(
-    "chomp_aggs should work from an R string with one grouping variable", {
+test_that("chomp_aggs should work from an R string with one grouping variable", {
     oneVarJSON <- '{"took": 5,
           "timed_out": false,
           "_shards": {"total": 16, "successful": 16, "failed": 0},
@@ -36,16 +35,16 @@ test_that(
 })
 
 # Works w/ one variable from a file
-test_that("chomp_aggs should work from a file with one grouping variable",
-          {test_json <- system.file("testdata", "one_var_agg.json", package = "uptasticsearch")
+test_that("chomp_aggs should work from a file with one grouping variable", {
+          test_json <- system.file("testdata", "one_var_agg.json", package = "uptasticsearch")
           expect_identical(chomp_aggs(aggs_json = test_json)
                            , data.table::data.table(some_variable = c("level1", "level2", "level3")
-                                                    , doc_count = c(62159L, 21576L, 10575L)))}
-)
+                                                    , doc_count = c(62159L, 21576L, 10575L)))
+})
 
 # Works with multiple grouping vars from an R string
-test_that("chomp_aggs should work from an R string with multiple grouping variables",
-          {oneVarJSON <- '{"took":494,"timed_out":false,"_shards":{"total":16,"successful":16,"failed":0},"hits":{"total":11335918,"max_score":0,"hits":[]},"aggregations":{"a_grouping_var":{"doc_count_error_upper_bound":0,"sum_other_doc_count":526088,"buckets":[{"key":0,"doc_count":3403964,"another_one":{"doc_count_error_upper_bound":23422,"sum_other_doc_count":2941783,"buckets":[{"key":2915,"doc_count":188629,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":168098},{"key":"tech_n9ne","doc_count":20531}]}},{"key":3952,"doc_count":146357,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":145484},{"key":"tech_n9ne","doc_count":873}]}},{"key":2632,"doc_count":127195,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":121318},{"key":"tech_n9ne","doc_count":5877}]}}]}},{"key":2,"doc_count":3360049,"another_one":{"doc_count_error_upper_bound":13449,"sum_other_doc_count":2105828,"buckets":[{"key":2349,"doc_count":542582,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"childish_gambino","doc_count":485820},{"key":"tech_n9ne","doc_count":56762}]}},{"key":2201,"doc_count":505387,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"childish_gambino","doc_count":470503},{"key":"tech_n9ne","doc_count":34884}]}},{"key":2247,"doc_count":206252,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"childish_gambino","doc_count":188375},{"key":"tech_n9ne","doc_count":17877}]}}]}},{"key":1,"doc_count":2600800,"another_one":{"doc_count_error_upper_bound":17346,"sum_other_doc_count":1692470,"buckets":[{"key":2126,"doc_count":433735,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":405476},{"key":"tech_n9ne","doc_count":28259}]}},{"key":777,"doc_count":277387,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":241894},{"key":"tech_n9ne","doc_count":35493}]}},{"key":663,"doc_count":197208,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":193540},{"key":"tech_n9ne","doc_count":3668}]}}]}}]}}}'
+test_that("chomp_aggs should work from an R string with multiple grouping variables", {
+          oneVarJSON <- '{"took":494,"timed_out":false,"_shards":{"total":16,"successful":16,"failed":0},"hits":{"total":11335918,"max_score":0,"hits":[]},"aggregations":{"a_grouping_var":{"doc_count_error_upper_bound":0,"sum_other_doc_count":526088,"buckets":[{"key":0,"doc_count":3403964,"another_one":{"doc_count_error_upper_bound":23422,"sum_other_doc_count":2941783,"buckets":[{"key":2915,"doc_count":188629,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":168098},{"key":"tech_n9ne","doc_count":20531}]}},{"key":3952,"doc_count":146357,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":145484},{"key":"tech_n9ne","doc_count":873}]}},{"key":2632,"doc_count":127195,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":121318},{"key":"tech_n9ne","doc_count":5877}]}}]}},{"key":2,"doc_count":3360049,"another_one":{"doc_count_error_upper_bound":13449,"sum_other_doc_count":2105828,"buckets":[{"key":2349,"doc_count":542582,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"childish_gambino","doc_count":485820},{"key":"tech_n9ne","doc_count":56762}]}},{"key":2201,"doc_count":505387,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"childish_gambino","doc_count":470503},{"key":"tech_n9ne","doc_count":34884}]}},{"key":2247,"doc_count":206252,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"childish_gambino","doc_count":188375},{"key":"tech_n9ne","doc_count":17877}]}}]}},{"key":1,"doc_count":2600800,"another_one":{"doc_count_error_upper_bound":17346,"sum_other_doc_count":1692470,"buckets":[{"key":2126,"doc_count":433735,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":405476},{"key":"tech_n9ne","doc_count":28259}]}},{"key":777,"doc_count":277387,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":241894},{"key":"tech_n9ne","doc_count":35493}]}},{"key":663,"doc_count":197208,"yet_another_one":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"lupe_fiasco","doc_count":193540},{"key":"tech_n9ne","doc_count":3668}]}}]}}]}}}'
           xDT <- chomp_aggs(aggs_json = oneVarJSON)
           yDT <- data.table::data.table(a_grouping_var = c(rep(0L, 6), rep(2L, 6), rep(1L, 6))
                                         , another_one = c(2915L, 2915L, 3952L, 3952L, 2632L, 2632L,
@@ -58,11 +57,11 @@ test_that("chomp_aggs should work from an R string with multiple grouping variab
                                                         485820L, 56762L, 470503L, 34884L, 188375L, 17877L,
                                                         405476L, 28259L, 241894L, 35493L, 193540L, 3668L))
           expect_identical(xDT, yDT)
-          })
+})
 
 # Works with multiple variables from a file
-test_that("chomp_aggs should work from a file with multiple grouping variables",
-          {test_json <- system.file("testdata", "three_var_agg.json", package = "uptasticsearch")
+test_that("chomp_aggs should work from a file with multiple grouping variables", {
+          test_json <- system.file("testdata", "three_var_agg.json", package = "uptasticsearch")
           expect_identical(chomp_aggs(aggs_json = test_json)
                            , data.table::data.table(a_grouping_var = c(rep(0L, 6), rep(2L, 6), rep(1L, 6))
                                                     , another_one = c(2915L, 2915L, 3952L, 3952L, 2632L, 2632L,
@@ -73,12 +72,12 @@ test_that("chomp_aggs should work from a file with multiple grouping variables",
                                                                           rep(c("lupe_fiasco", "tech_n9ne"), 3))
                                                     , doc_count = c(168098L, 20531L, 145484L, 873L, 121318L, 5877L,
                                                                     485820L, 56762L, 470503L, 34884L, 188375L, 17877L,
-                                                                    405476L, 28259L, 241894L, 35493L, 193540L, 3668L)))}
-)
+                                                                    405476L, 28259L, 241894L, 35493L, 193540L, 3668L)))
+})
 
 # Works from a multi-element character vector (1 variable and multi-var)
-test_that("chomp_aggs should work from a multi-element character vector",
-          {test_json <- system.file("testdata", "three_var_agg.json", package = "uptasticsearch")
+test_that("chomp_aggs should work from a multi-element character vector", {
+          test_json <- system.file("testdata", "three_var_agg.json", package = "uptasticsearch")
           jsonVec <- suppressWarnings(readLines(test_json))
           chompDT <- chomp_aggs(aggs_json = jsonVec)
           expect_identical(chompDT
@@ -91,26 +90,25 @@ test_that("chomp_aggs should work from a multi-element character vector",
                                                                           rep(c("lupe_fiasco", "tech_n9ne"), 3))
                                                     , doc_count = c(168098L, 20531L, 145484L, 873L, 121318L, 5877L,
                                                                     485820L, 56762L, 470503L, 34884L, 188375L, 17877L,
-                                                                    405476L, 28259L, 241894L, 35493L, 193540L, 3668L)))}
-)
+                                                                    405476L, 28259L, 241894L, 35493L, 193540L, 3668L)))
+})
 
 # Returns NULL if you don't pass in any data
-test_that("chomp_aggs should return NULL and warn if you don't give it any data",
-          {chompResult <- suppressWarnings(chomp_aggs(aggs_json = NULL))
+test_that("chomp_aggs should return NULL and warn if you don't give it any data", {
+          chompResult <- suppressWarnings(chomp_aggs(aggs_json = NULL))
           expect_true(is.null(chompResult))
           expect_warning(chomp_aggs(aggs_json = NULL),
-                         regexp = "You did not pass any input data to chomp_aggs")}
-)
+                         regexp = "You did not pass any input data to chomp_aggs")
+})
 
 # Should break with an informative error if you pass something weird (not a list or character) to chomp_aggs
-test_that("chomp_aggs should break with an informative error for malformed inputs",
-          {expect_error(chomp_aggs(aggs_json = list(a = 1, b = "2")),
-                        regexp = "The first argument of chomp_aggs must be a character vector")}
-)
+test_that("chomp_aggs should break with an informative error for malformed inputs", {
+          expect_error(chomp_aggs(aggs_json = list(a = 1, b = "2")),
+                        regexp = "The first argument of chomp_aggs must be a character vector")
+})
 
 # [cardinality] chomp_aggs should work for a one-level cardinality result
-test_that("chomp_aggs should work for a one-level 'cardinality' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'cardinality' aggregation", {
               result <- system.file("testdata", "aggs_cardinality.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -118,11 +116,10 @@ test_that("chomp_aggs should work for a one-level 'cardinality' aggregation",
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 1)
               expect_identical(chompDT, data.table::data.table(number_of_things.value = 777L))
-          })
+})
 
 # [date_histogram] chomp_aggs should work for a one-level date_histogram result
-test_that("chomp_aggs should work for a one-level 'date_histogram' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'date_histogram' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -131,11 +128,10 @@ test_that("chomp_aggs should work for a one-level 'date_histogram' aggregation",
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 10)
               expect_identical(chompDT[10, report_week], "2017-05-01T00:00:00.000Z")
-          })
+})
 
 # [date_histogram-cardinality] chomp_aggs should work for a date_histogram-cardinality result
-test_that("chomp_aggs should work for a 'date_histogram' - 'cardinality' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'cardinality' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_cardinality.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -145,11 +141,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'cardinality' aggrega
               expect_true(nrow(chompDT) == 10)
               expect_identical(chompDT[10, report_week], "2017-05-01T00:00:00.000Z")
               expect_identical(sort(chompDT[, unique(num_customers.value)]), c(4L, 5L))
-          })
+})
 
 # [date_histogram-extended_stats] chomp_aggs should work for a date_histogram-extended_stats result
-test_that("chomp_aggs should work for a 'date_histogram' - 'extended_stats' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'extended_stats' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_extended_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -165,11 +160,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'extended_stats' aggr
               expect_true(nrow(chompDT) == 10)
               expect_identical(chompDT[10, report_week], "2017-05-01T00:00:00.000Z")
               expect_identical(sort(chompDT[, unique(some_score.max)]), c(3L, 7L))
-          })
+})
 
 # [date_histogram-histogram] chomp_aggs should work for a date_histogram-histogram result
-test_that("chomp_aggs should work for a 'date_histogram' - 'histogram' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'histogram' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_histogram.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -179,11 +173,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'histogram' aggregati
               expect_true(nrow(chompDT) == 26)
               expect_identical(chompDT[26, report_week], "2017-05-01T00:00:00.000Z")
               expect_identical(sort(chompDT[, unique(num_customers)]), c(0L, 2L, 6L))
-          })
+})
 
 # [date_histogram-percentiles] chomp_aggs should work for a date_histogram-percentiles result
-test_that("chomp_aggs should work for a 'date_histogram' - 'percentiles' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'percentiles' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_percentiles.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -198,11 +191,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'percentiles' aggrega
               expect_identical(chompDT[10, report_week], "2017-05-01T00:00:00.000Z")
               expect_true(all(chompDT$some_score.values.99.0 > 50))
               expect_true(all(chompDT$some_score.values.99.0 < 60))
-          })
+})
 
 # [date_histogram-significant_terms] chomp_aggs should work for a date_histogram-significant_terms result
-test_that("chomp_aggs should work for a 'date_histogram' - 'significant_terms' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'significant_terms' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_significant_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -217,11 +209,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'significant_terms' a
                                    "glorious", "history", "no", "nor", "norm",
                                    "normal", "preposterous", "sa", "sam", "samp",
                                    "sampl", "think"))
-          })
+})
 
 # [date_histogram-stats] chomp_aggs should work for a date_histogram-stats result
-test_that("chomp_aggs should work for a 'date_histogram' - 'stats' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'stats' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -233,11 +224,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'stats' aggregation",
               expect_true(nrow(chompDT) == 10)
               expect_identical(chompDT[10, report_week], "2017-05-01T00:00:00.000Z")
               expect_identical(sort(chompDT[, unique(some_score.max)]), c(3L, 7L))
-          })
+})
 
 # [date_histogram-terms] chomp_aggs should work for a date_histogram-terms result
-test_that("chomp_aggs should work for a 'date_histogram' - 'terms' aggregation",
-          {
+test_that("chomp_aggs should work for a 'date_histogram' - 'terms' aggregation", {
               result <- system.file("testdata", "aggs_date_histogram_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -248,11 +238,10 @@ test_that("chomp_aggs should work for a 'date_histogram' - 'terms' aggregation",
               expect_identical(chompDT[31, report_week], "2017-05-01T00:00:00.000Z")
               expect_identical(sort(chompDT[, unique(theater_number)]), c(0L, 1L, 2L, 3L))
               expect_true(max(chompDT$doc_count) == 8306)
-          })
+})
 
 # [extended_stats] chomp_aggs should work for a one-level extended_stats result
-test_that("chomp_aggs should work for a one-level 'extended_stats' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'extended_stats' aggregation", {
               result <- system.file("testdata", "aggs_extended_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -271,11 +260,10 @@ test_that("chomp_aggs should work for a one-level 'extended_stats' aggregation",
               expect_true(nrow(chompDT) == 1)
               expect_true(is.integer(chompDT[, affinity_score.count]))
               expect_true(sum(sapply(chompDT, class) == 'numeric') == 9) # all but count will be numeric
-          })
+})
 
 # [histogram] chomp_aggs should work for a histogram result
-test_that("chomp_aggs should work for a 'histogram' aggregation",
-          {
+test_that("chomp_aggs should work for a 'histogram' aggregation", {
               result <- system.file("testdata", "aggs_histogram.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -284,11 +272,10 @@ test_that("chomp_aggs should work for a 'histogram' aggregation",
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 5)
               expect_identical(chompDT$affinity_score, c(-50L, -25L, 0L, 25L, 50L))
-          })
+})
 
 # [percentiles] chomp_aggs should work for a one-level percentiles result
-test_that("chomp_aggs should work for a one-level 'percentiles' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'percentiles' aggregation", {
               result <- system.file("testdata", "aggs_percentiles.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -304,11 +291,10 @@ test_that("chomp_aggs should work for a one-level 'percentiles' aggregation",
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 1)
               expect_identical(round(chompDT[1, affinity_score.percentile_99.0], 2), 55.49)
-          })
+})
 
 # [significant_terms] chomp_aggs should work for a one-level significant_terms result
-test_that("chomp_aggs should work for a one-level 'significant terms' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'significant terms' aggregation", {
               result <- system.file("testdata", "aggs_significant_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -322,11 +308,10 @@ test_that("chomp_aggs should work for a one-level 'significant terms' aggregatio
               expect_true(is.integer(chompDT[, doc_count]))
               expect_identical(chompDT[, top_tweet_keywords], c('no', 'cont', 'sa', 'norm', 'nor'))
               expect_identical(chompDT[, bg_count], c(384901L, 328493L, 330583L, 340281L, 340300L))
-          })
+})
 
 # [stats] chomp_aggs should work for a one-level stats result
-test_that("chomp_aggs should work for a one-level 'stats' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'stats' aggregation", {
               result <- system.file("testdata", "aggs_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -340,11 +325,10 @@ test_that("chomp_aggs should work for a one-level 'stats' aggregation",
               expect_true(nrow(chompDT) == 1)
               expect_true(is.integer(chompDT[, affinity_score.count]))
               expect_true(sum(sapply(chompDT, class) == 'numeric') == 4) # all but count will be numeric
-          })
+})
 
 # [terms] chomp_aggs should work for a one-level terms result
-test_that("chomp_aggs should work for a one-level 'terms' aggregation",
-          {
+test_that("chomp_aggs should work for a one-level 'terms' aggregation", {
               result <- system.file("testdata", "aggs_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -352,11 +336,10 @@ test_that("chomp_aggs should work for a one-level 'terms' aggregation",
                            , ignore.order = FALSE, ignore.case = FALSE)
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 10)
-          })
+})
 
 # [terms-cardinality chomp_aggs should work for a terms - cardinality nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'cardinality' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'cardinality' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_cardinality.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -365,11 +348,10 @@ test_that("chomp_aggs should work for a 'terms' - 'cardinality' nested aggregati
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 3)
               expect_identical(chompDT$purchase_types.value, c(4L, 4L, 2L))
-          })
+})
 
 # [terms-date_histogram] chomp_aggs should work for a terms - date_histogram nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -380,11 +362,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' nested aggreg
               expect_identical(unique(chompDT$customerNumber), c(3L, 5L, 19L))
               expect_identical(chompDT[1, purchase_date], "2017-02-27T00:00:00.000Z")
               expect_identical(chompDT[30, purchase_date], "2017-05-01T00:00:00.000Z")
-          })
+})
 
 # [terms-date_histogram-cardinality] chomp_aggs should work for a terms - date_histogram - cardinality nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'cardinality' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'cardinality' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram_cardinality.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -395,11 +376,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'cardinalit
               expect_identical(chompDT[1, report_week], "2017-02-27T00:00:00.000Z")
               expect_identical(chompDT[30, report_week], "2017-05-01T00:00:00.000Z")
               expect_identical(sort(chompDT[, unique(theater_number)]), c(0L, 1L, 2L, 3L, 7L))
-          })
+})
 
 # [terms-date_histogram-extended_stats] chomp_aggs should work for a terms - date_histogram - extended_stats nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'extended_stats' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'extended_stats' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram_extended_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -419,11 +399,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'extended_s
               expect_identical(sort(chompDT[, unique(customer_type)])
                                , c('big_spender', 'movie_buff', 'popcorn_fiend',
                                    'weekend_warrior', 'your_nemesis'))
-          })
+})
 
 # [terms-date_histogram-percentiles] chomp_aggs should work for a terms - date_histogram - percentiles nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'percentiles' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'percentiles' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram_percentiles.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -445,11 +424,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'percentile
               expect_identical(sort(chompDT[, unique(customer_type)])
                                , c(0L, 1L, 2L, 3L, 7L))
               expect_true(chompDT[, min(satisfaction_score.values.1.0)] < -34.0)
-          })
+})
 
 # [terms-date_histogram-significant_terms] chomp_aggs should work for a terms - date_histogram - significant_terms nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'significant_terms' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'significant_terms' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram_significant_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -465,11 +443,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'significan
               expect_identical(chompDT[, min(report_week)], "2017-02-27T00:00:00.000Z")
               expect_identical(chompDT[, max(report_week)], "2017-05-01T00:00:00.000Z")
               expect_true('detergent' %in% chompDT$top_tweet_keywords)
-          })
+})
 
 # [terms-date_histogram-stats] chomp_aggs should work for a terms - date_histogram - stats nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'stats' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'stats' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -487,11 +464,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'stats' nes
               expect_identical(chompDT[, min(report_week)], "2017-02-27T00:00:00.000Z")
               expect_identical(chompDT[, max(report_week)], "2017-05-01T00:00:00.000Z")
               expect_true('big_spender' %in% chompDT[, unique(customer_type)])
-          })
+})
 
 # [terms-date_histogram-terms] chomp_aggs should work for a terms - date_histogram - terms nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'terms' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'terms' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_date_histogram_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -505,11 +481,10 @@ test_that("chomp_aggs should work for a 'terms' - 'date_histogram' - 'terms' nes
               expect_identical(chompDT[, min(report_week)], "2017-02-27T00:00:00.000Z")
               expect_identical(chompDT[, max(report_week)], "2017-05-01T00:00:00.000Z")
               expect_true('Jean Valjean' %in% chompDT$topCustomer)
-          })
+})
 
 # [terms-extended_stats] chomp_aggs should work for a terms - extended_stats nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'extended_stats' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'extended_stats' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_extended_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -523,13 +498,10 @@ test_that("chomp_aggs should work for a 'terms' - 'extended_stats' nested aggreg
                            , ignore.order = FALSE, ignore.case = FALSE)
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 3)
-          })
-
-
+})
 
 # [terms-histogram] chomp_aggs should work for a terms - histogram nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'histogram' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'histogram' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_histogram.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -538,11 +510,10 @@ test_that("chomp_aggs should work for a 'terms' - 'histogram' nested aggregation
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 7)
               expect_identical(sort(chompDT[, unique(affinity_score)]), c(-50L, 0L, 50L))
-          })
+})
 
 # [terms-percentiles] chomp_aggs should work for a terms - percentiles nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'percentiles' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'percentiles' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_percentiles.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -554,11 +525,10 @@ test_that("chomp_aggs should work for a 'terms' - 'percentiles' nested aggregati
                            , ignore.order = FALSE, ignore.case = FALSE)
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 3)
-          })
+})
 
 # [terms-significant_terms] chomp_aggs should work for a terms - significant_terms nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'significant_terms' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'significant_terms' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_significant_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -568,11 +538,10 @@ test_that("chomp_aggs should work for a 'terms' - 'significant_terms' nested agg
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 30)
               expect_identical(sort(chompDT[, unique(popularity_score)]), c('opinion', 'reviews', 'summaries'))
-          })
+})
 
 # [terms-stats] chomp_aggs should work for a terms - stats nested aggregation
-test_that("chomp_aggs should work for a 'terms' - 'stats' nested aggregation",
-          {
+test_that("chomp_aggs should work for a 'terms' - 'stats' nested aggregation", {
               result <- system.file("testdata", "aggs_terms_stats.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -583,11 +552,10 @@ test_that("chomp_aggs should work for a 'terms' - 'stats' nested aggregation",
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 3)
               expect_identical(sort(chompDT$customerNumber), c(3L, 9L, 19L))
-          })
+})
 
 # [terms-terms] chomp_aggs should work for a two-level terms result
-test_that("chomp_aggs should work for a two-level 'terms' aggregation",
-          {
+test_that("chomp_aggs should work for a two-level 'terms' aggregation", {
               result <- system.file("testdata", "aggs_terms_terms.json", package = "uptasticsearch")
               chompDT <- chomp_aggs(aggs_json = result)
 
@@ -596,7 +564,7 @@ test_that("chomp_aggs should work for a two-level 'terms' aggregation",
               expect_true(data.table::is.data.table(chompDT))
               expect_true(nrow(chompDT) == 3)
               expect_true(all(chompDT$customerType == 'type_a'))
-          })
+})
 
 # empty results
 test_that("chomp_aggs should work for an empty terms result", {

--- a/r-pkg/tests/testthat/test-chomp_hits.R
+++ b/r-pkg/tests/testthat/test-chomp_hits.R
@@ -1,7 +1,7 @@
 
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO

--- a/r-pkg/tests/testthat/test-chomp_hits.R
+++ b/r-pkg/tests/testthat/test-chomp_hits.R
@@ -9,8 +9,8 @@ if (!identical(loggerOptions, list())){
 futile.logger::flog.threshold(0)
 
 # This is effectively a test of running elastic::Search(raw = TRUE) and passing it through chomp_hits()
-test_that("chomp_hits should work from a one-element character vector",
-          {jsonString <- '{"took": 54, "timed_out": false, "_shards": {"total": 16,"successful": 16, "failed": 0},
+test_that("chomp_hits should work from a one-element character vector", {
+          jsonString <- '{"took": 54, "timed_out": false, "_shards": {"total": 16,"successful": 16, "failed": 0},
           "hits": {
           "total": 46872,
           "max_score": 0.882234,
@@ -39,12 +39,12 @@ test_that("chomp_hits should work from a one-element character vector",
                             "stats.full_career.HR", "stats.full_career.R", "stats.yrs_played", "_type") %in%
                               names(chompDT)))
           expect_identical(chompDT$stats.full_career.R, as.integer(c(1419, 653, 579, 1544, 664)))
-          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))}
-)
+          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))
+})
 
 # What if we're passing the hits array, not the entire result?
-test_that("chomp_hits should work with just the hits array",
-          {jsonString <- '[
+test_that("chomp_hits should work with just the hits array", {
+          jsonString <- '[
           {"_index": "redsawx", "_type": "ballplayer", "_id": "abc123", "_score": 0.882234,
           "_source": {"name": "David Ortiz", "stats" : {"yrs_played": 20, "final_season": {"avg": 0.315, "HR": 38, "R": 79},
           "full_career": {"avg": 0.286, "HR": 541, "R": 1419}}}},
@@ -69,12 +69,12 @@ test_that("chomp_hits should work with just the hits array",
                             "stats.full_career.HR", "stats.full_career.R", "stats.yrs_played", "_type") %in%
                               names(chompDT)))
           expect_identical(chompDT$stats.full_career.R, as.integer(c(1419, 653, 579, 1544, 664)))
-          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))}
-)
+          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))
+})
 
 # This tests the type of data representation you'd get from reading in a JSON file with readLines
-test_that("chomp_hits should work from a multi-element character vector",
-          {test_json <- system.file("testdata", "es_hits.json", package = "uptasticsearch")
+test_that("chomp_hits should work from a multi-element character vector", {
+          test_json <- system.file("testdata", "es_hits.json", package = "uptasticsearch")
           jsonVec <- suppressWarnings(readLines(test_json))
           chompDT <- chomp_hits(hits_json = jsonVec)
           expect_true(data.table::is.data.table(chompDT))
@@ -84,12 +84,12 @@ test_that("chomp_hits should work from a multi-element character vector",
                             "stats.full_career.HR", "stats.full_career.R", "stats.yrs_played", "_type") %in%
                               names(chompDT)))
           expect_identical(chompDT$stats.full_career.R, as.integer(c(1419, 653, 579, 1544, 664)))
-          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))}
-)
+          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))
+})
 
 # In case you need to have a non-R, non-Python run queries for you and store them in a file
-test_that("chomp_hits should work from a file",
-          {test_json <- system.file("testdata", "es_hits.json", package = "uptasticsearch")
+test_that("chomp_hits should work from a file", {
+          test_json <- system.file("testdata", "es_hits.json", package = "uptasticsearch")
           chompDT <- chomp_hits(hits_json = test_json)
           expect_true(data.table::is.data.table(chompDT))
           expect_equivalent(dim(chompDT), c(5, 12))
@@ -98,30 +98,33 @@ test_that("chomp_hits should work from a file",
                             "stats.full_career.HR", "stats.full_career.R", "stats.yrs_played", "_type") %in%
                               names(chompDT)))
           expect_identical(chompDT$stats.full_career.R, as.integer(c(1419, 653, 579, 1544, 664)))
-          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))}
-)
+          expect_identical(chompDT$stats.full_career.HR, as.character(c(541, 150, 137, 555, 193)))
+})
 
 # Should warn and return null if you don't provide any data
-test_that("chomp_hits should return NULL if you do not provide data",
-          {result <- suppressWarnings(chomp_hits(hits_json = NULL))
+test_that("chomp_hits should return NULL if you do not provide data", {
+          result <- suppressWarnings(chomp_hits(hits_json = NULL))
           expect_true(is.null(result))
           expect_warning(chomp_hits(hits_json = NULL),
-                         regexp = "You did not pass any input data to chomp_hits")}
-)
+                         regexp = "You did not pass any input data to chomp_hits")
+})
 
 # Should break if you pass the wrong kind of input
-test_that("chomp_hits should break if you pass the wrong input",
-          {expect_error(chomp_hits(hits_json = data.frame(a = 1:5)),
-                        regexp = "The first argument of chomp_hits must be a character vector")}
-)
+test_that("chomp_hits should break if you pass the wrong input", {
+          expect_error(chomp_hits(hits_json = data.frame(a = 1:5)),
+                        regexp = "The first argument of chomp_hits must be a character vector")
+})
 
 # Should warn if the resulting data is nested with default keep_nested_data_cols = FALSE
-test_that("chomp_hits should warn and delete if the resulting data is nested with keep_nested_data_cols = FALSE",
-          {expect_warning({chomped <- chomp_hits(hits_json = '[{"test1":[{"a":1}],"test2":2}]'
-                                                 , keep_nested_data_cols = FALSE)},
-                          regexp = "Deleting the following nested data columns:")
-              expect_equal(names(chomped), "test2")}
-)
+test_that("chomp_hits should warn and delete if the resulting data is nested with keep_nested_data_cols = FALSE", {
+    expect_warning({
+        chomped <- chomp_hits(
+            hits_json = '[{"test1":[{"a":1}],"test2":2}]'
+            , keep_nested_data_cols = FALSE
+        )
+    }, regexp = "Deleting the following nested data columns:")
+    expect_equal(names(chomped), "test2")
+})
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)

--- a/r-pkg/tests/testthat/test-es_search.R
+++ b/r-pkg/tests/testthat/test-es_search.R
@@ -1,7 +1,7 @@
 
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO
@@ -112,7 +112,7 @@ test_that(".ValidateAndFormatHost should warn and use http if you don't give a p
 test_that(".major_version should correctly parse semver version strings", {
 
     # yay random tests
-    for (i in 1:50){
+    for (i in 1:50) {
         v1 <- as.character(sample(0:9, size = 1))
         v2 <- as.character(sample(0:9, size = 1))
         v3 <- as.character(sample(0:9, size = 1))

--- a/r-pkg/tests/testthat/test-es_search.R
+++ b/r-pkg/tests/testthat/test-es_search.R
@@ -84,8 +84,7 @@ test_that(".ValidateAndFormatHost should break if you give it a multi-element ve
                        , regexp = "es_host should be length 1"))
 
 # .ValidateAndFormatHost should warn you and drop trailing slashes if you have them
-test_that(".ValidateAndFormatHost should handle trailing slashes",
-          {
+test_that(".ValidateAndFormatHost should handle trailing slashes", {
               # single slash
               newHost <- uptasticsearch:::.ValidateAndFormatHost("http://mydb.mycompany.com:9200/")
               expect_identical(newHost, "http://mydb.mycompany.com:9200")
@@ -93,7 +92,7 @@ test_that(".ValidateAndFormatHost should handle trailing slashes",
               # objectively ridiculous number of slashes
               newHost2 <- uptasticsearch:::.ValidateAndFormatHost("http://mydb.mycompany.com:9200/////////")
               expect_identical(newHost2, "http://mydb.mycompany.com:9200")
-          })
+})
 
 # .ValidateAndFormatHost should break if you don't have a port
 test_that(".ValidateAndFormatHost should break if you don't have a port",
@@ -101,13 +100,13 @@ test_that(".ValidateAndFormatHost should break if you don't have a port",
                        , regexp = "No port found in es_host"))
 
 # .ValidateAndFormatHost should warn if you don't have a valid transfer protocol
-test_that(".ValidateAndFormatHost should warn and use http if you don't give a port",
-          {
-              # single slash
-              expect_warning({hostWithTransfer <- uptasticsearch:::.ValidateAndFormatHost("mydb.mycompany.com:9200")}
-                             , regexp = "You did not provide a transfer protocol")
-              expect_identical(hostWithTransfer, "http://mydb.mycompany.com:9200")
-          })
+test_that(".ValidateAndFormatHost should warn and use http if you don't give a port", {
+    # single slash
+    expect_warning({
+        hostWithTransfer <- uptasticsearch:::.ValidateAndFormatHost("mydb.mycompany.com:9200")
+    }, regexp = "You did not provide a transfer protocol")
+    expect_identical(hostWithTransfer, "http://mydb.mycompany.com:9200")
+})
 
 #---- .major_version
 test_that(".major_version should correctly parse semver version strings", {

--- a/r-pkg/tests/testthat/test-get_fields.R
+++ b/r-pkg/tests/testthat/test-get_fields.R
@@ -11,23 +11,21 @@ futile.logger::flog.threshold(0)
 #--- get_fields
 
     # Gives an informative error if es_indices is NULL or an empty string
-    test_that("get_fields should give an informative error if es_indices is NULL or an empty string",
-              {
+    test_that("get_fields should give an informative error if es_indices is NULL or an empty string", {
                   expect_error(get_fields(es_host = "http://es.custdb.mycompany.com:9200"
                                           , es_indices = NULL),
                                regexp = "not greater than 0")
                   expect_error(get_fields(es_host = "http://es.custdb.mycompany.com:9200"
                                           , es_indices = ''),
                                regexp = "get_fields must be passed a valid es_indices")
-              }
-    )
+    })
 
     # works as expected when mocked
-    test_that('get_fields works as expected when mocked',
-              {
+    test_that('get_fields works as expected when mocked', {
                   test_json <- system.file("testdata", "two_index_mapping.json", package = "uptasticsearch")
                   aliasDT <- data.table::data.table(alias = c('alias1', 'alias2')
                                                     , index = c('company', 'otherIndex'))
+                  # nolint start
                   testthat::with_mock(
                       `httr::stop_for_status` = function(...) {return(NULL)},
                       `httr::RETRY` = function(...) {return(NULL)},
@@ -49,15 +47,13 @@ futile.logger::flog.threshold(0)
                           expect_identical(outDT, expected)
                       }
                   )
-              }
-    )
-
+                  # nolint end
+    })
 
 #--- .flatten_mapping
 
     # Works if one index is passed
-    test_that(".flatten_mapping should work if the mapping for one index is provided",
-              {
+    test_that(".flatten_mapping should work if the mapping for one index is provided", {
                   test_json <- system.file("testdata", "one_index_mapping.json", package = "uptasticsearch")
                   mapping <- jsonlite::fromJSON(txt = test_json)
                   mappingDT <- uptasticsearch:::.flatten_mapping(mapping = mapping)
@@ -68,12 +64,10 @@ futile.logger::flog.threshold(0)
                       , data_type = c('keyword', 'text', 'text', 'integer', 'keyword')
                   )
                   expect_identical(mappingDT, expected)
-              }
-    )
+    })
 
     # works if multiple indices are passed
-    test_that(".flatten_mapping should work if the mapping for multiple indices are provided",
-              {
+    test_that(".flatten_mapping should work if the mapping for multiple indices are provided", {
                   test_json <- system.file("testdata", "two_index_mapping.json", package = "uptasticsearch")
                   mapping <- jsonlite::fromJSON(txt = test_json)
                   mappingDT <- uptasticsearch:::.flatten_mapping(mapping = mapping)
@@ -86,30 +80,25 @@ futile.logger::flog.threshold(0)
                                       , 'text', 'keyword')
                   )
                   expect_identical(mappingDT, expected)
-              }
-    )
+    })
 
 #--- .process_alias
 
     # works if one alias is passed
-    test_that(".process_new_alias works if one alias is included",
-              {
+    test_that(".process_new_alias works if one alias is included", {
                   alias_string <- 'dwm shakespeare - - -\n'
                   aliasDT <- uptasticsearch:::.process_new_alias(alias_string = alias_string)
                   expected <- data.table::data.table(alias = 'dwm', index = 'shakespeare')
                   expect_identical(aliasDT, expected)
-              }
-    )
+    })
 
     # works if multiple aliases are passed
-    test_that(".process_new_alias works if one alias is included",
-              {
+    test_that(".process_new_alias works if one alias is included", {
                   alias_string <- 'dwm   shakespeare - - -\nmoney bank        - - -\n'
                   aliasDT <- uptasticsearch:::.process_new_alias(alias_string = alias_string)
                   expected <- data.table::data.table(alias = c('dwm', 'money'), index = c('shakespeare', 'bank'))
                   expect_identical(aliasDT, expected)
-              }
-    )
+    })
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)

--- a/r-pkg/tests/testthat/test-get_fields.R
+++ b/r-pkg/tests/testthat/test-get_fields.R
@@ -1,6 +1,6 @@
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -211,7 +211,7 @@ futile.logger::flog.threshold(0)
         res <- httr::RETRY(
             verb = "POST"
             , url = "http://127.0.0.1:9200/_aliases"
-            , httr::add_headers(c('Content-Type' = 'application/json'))
+            , httr::add_headers(c('Content-Type' = 'application/json'))  # nolint[non_portable_path]
             , body = sprintf(
                 '{"actions": [{"%s": {"index": "shakespeare", "alias": "%s"}}]}'
                 , action

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -7,7 +7,7 @@
 
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO
@@ -131,7 +131,7 @@ futile.logger::flog.threshold(0)
         major_version <- .major_version(
             .get_es_version("http://127.0.0.1:9200")
         )
-        if (as.integer(major_version) >= 7){
+        if (as.integer(major_version) >= 7) {
             num_expected_levels <- 3
         }
         expect_true(nrow(outDT) == num_expected_levels)
@@ -207,7 +207,7 @@ futile.logger::flog.threshold(0)
 
     # set up helper function for manipulating aliases. Valid actions below are
     # "add" and "remove"
-    .alias_action <- function(action, alias_name){
+    .alias_action <- function(action, alias_name) {
         res <- httr::RETRY(
             verb = "POST"
             , url = "http://127.0.0.1:9200/_aliases"

--- a/r-pkg/tests/testthat/test-parse_date_time.R
+++ b/r-pkg/tests/testthat/test-parse_date_time.R
@@ -126,7 +126,7 @@ test_that("parse_date_time should give an informative error if you don't pass it
 
     expect_error({
         parse_date_time(testDF, date_cols = "dateTime")
-    }, regexp = "parse_date_time expects to receive a data\\.table object")
+    }, regexp = "parse_date_time expects to receive a data\\.table object")  # nolint[non_portable_path]
 })
 
 # Gives informative error if you ask to adjust date_cols that don't exist

--- a/r-pkg/tests/testthat/test-parse_date_time.R
+++ b/r-pkg/tests/testthat/test-parse_date_time.R
@@ -1,6 +1,6 @@
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO

--- a/r-pkg/tests/testthat/test-unpack_nested_data.R
+++ b/r-pkg/tests/testthat/test-unpack_nested_data.R
@@ -11,8 +11,8 @@ futile.logger::flog.threshold(0)
 #--- unpack_nested_data
 
     # Should work with result of chomp_hits
-    test_that("unpack_nested_data should work with the result of chomp_hits",
-              {test_json <- '[{"_source":{"dateTime":"2017-01-01","username":"Austin1","details":{
+    test_that("unpack_nested_data should work with the result of chomp_hits", {
+        test_json <- '[{"_source":{"dateTime":"2017-01-01","username":"Austin1","details":{
                 "interactions":400,"userType":"active","appData":[{"appName":"farmville","minutes":500},
                 {"appName":"candy_crush","value":350},{"appName":"angry_birds","typovalue":422}]}}},
                 {"_source":{"dateTime":"2017-02-02","username":"Austin2","details":{"interactions":5,
@@ -32,11 +32,11 @@ futile.logger::flog.threshold(0)
                                                      'block_dude'))
               expect_identical(unpackedDT$username, c(rep("Austin1", 3), rep("Austin2", 4)))
               expect_true(sum(is.na(unpackedDT$minutes)) == 6)
-             })
+    })
 
     # Should work if the array is a simple array rather than an array of maps
-    test_that("unpack_nested_data should work if the array is a simple array",
-              {test_json <- '[{"_source":{"dateTime":"2017-01-01","username":"Austin1","details":{
+    test_that("unpack_nested_data should work if the array is a simple array", {
+        test_json <- '[{"_source":{"dateTime":"2017-01-01","username":"Austin1","details":{
               "interactions":400,"userType":"active","minutes":[500,350,422]}}},
               {"_source":{"dateTime":"2017-02-02","username":"Austin2","details":{"interactions":0,
               "userType":"never","minutes":[]}}},
@@ -52,44 +52,44 @@ futile.logger::flog.threshold(0)
                                          'details.userType', 'details.minutes'))
               expect_equivalent(unpackedDT$details.minutes, c(500, 350, 422, NA, 28, 190, 1, 796))
               expect_identical(unpackedDT$username, c(rep("Austin1", 3), "Austin2", rep("Austin3", 4)))
-              })
+    })
 
     # Should break if chomped_df is not a data.table
-    test_that("unpack_nested_data should break if you don't pass a data.table",
-              {expect_error(unpack_nested_data(chomped_df = 42
+    test_that("unpack_nested_data should break if you don't pass a data.table", {
+        expect_error(unpack_nested_data(chomped_df = 42
                                                , col_to_unpack = "blah"),
-                            regexp = "chomped_df must be a data.table")}
-             )
+                            regexp = "chomped_df must be a data.table")
+    })
 
     # Should break if col_to_unpack is not a string
-    test_that("unpack_nested_data should break if col_to_unpack is not a string",
-              {expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
+    test_that("unpack_nested_data should break if col_to_unpack is not a string", {
+        expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
                                                , col_to_unpack = 8),
-                            regexp = "col_to_unpack must be a character of length 1")}
-             )
+                            regexp = "col_to_unpack must be a character of length 1")
+    })
 
     # Should break if col_to_unpack is not of length 1
-    test_that("unpack_nested_data should break if col_to_unpack is not of length 1",
-              {expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
+    test_that("unpack_nested_data should break if col_to_unpack is not of length 1", {
+        expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
                                                , col_to_unpack = c("a", "b")),
-                            regexp = "col_to_unpack must be a character of length 1")}
-             )
+                            regexp = "col_to_unpack must be a character of length 1")
+    })
 
     # Should break if col_to_unpack is not one of the column names
-    test_that("unpack_nested_data should break if col_to_unpack is not one of the column names",
-              {expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
+    test_that("unpack_nested_data should break if col_to_unpack is not one of the column names", {
+        expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
                                                , col_to_unpack = "a"),
-                            regexp = "col_to_unpack must be one of the column names")}
-             )
+                            regexp = "col_to_unpack must be one of the column names")
+    })
 
     # Should break if the column doesn't include any data
-    test_that("unpack_nested_data should break if the column doesn't include any data",
-              {expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7, dang = list())
+    test_that("unpack_nested_data should break if the column doesn't include any data", {
+        expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7, dang = list())
                                                , col_to_unpack = "dang"),
-                            regexp = "The column given to unpack_nested_data had no data in it")}
-    )
+                            regexp = "The column given to unpack_nested_data had no data in it")
+    })
 
-    test_that("unpack_nested_data should break if the column contains a non data frame/vector", {
+    test_that("unpack_nested_data should break if the column contains something that is not a dataframe or vector", {
         DT <- data.table::data.table(x = 1:2, y = list(list(2), 3))
         expect_error(unpack_nested_data(chomped_df = DT, col_to_unpack = "y")
                      , regexp = "must be a data frame or a vector")

--- a/r-pkg/tests/testthat/test-unpack_nested_data.R
+++ b/r-pkg/tests/testthat/test-unpack_nested_data.R
@@ -1,7 +1,7 @@
 
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
-if (!identical(loggerOptions, list())){
+if (!identical(loggerOptions, list())) {
     origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
     origLogThreshold <- futile.logger::INFO


### PR DESCRIPTION
* re-enables all the `{lintr}` linters we'd been using previously
* resolved these types of warnings from `{lintr}`:

```text
[braces] There should be a space before an opening curly brace.
[closed_curly] Closing curly-braces should always be on their own line, unless they are followed by an else.
[commas] Commas should always have a space after.
[infix_spaces] Put spaces around all infix operators.
[non_portable_path] Use file.path() to construct portable file paths.
[semicolon] Compound semicolons are discouraged. Replace them by a newline.
```

* resolved these deprecation warnings from `{lintr}`:

```text
1: Linter closed_curly_linter was deprecated in lintr version 3.0.0. Use brace_linter instead. 
2: Linter no_tab_linter was deprecated in lintr version 3.1.0. Use whitespace_linter instead. 
3: Linter open_curly_linter was deprecated in lintr version 3.0.0. Use brace_linter instead. 
4: Linter semicolon_terminator_linter was deprecated in lintr version 3.0.0. Use semicolon_linter instead. 
5: Linter unneeded_concatenation_linter was deprecated in lintr version 3.1.0. Use unnecessary_concatenation_linter instead.
```

* added `tidy` to CI environment, to more closely match `R CMD check --as-cran` and resolve this NOTE from it:

```text
* checking HTML version of manual ... NOTE
Skipping checking HTML validation: no command 'tidy' found
```

* set `MAKEFLAGS="-j4"` to speed up compilation of all those R packages we end up building from source on every run
* added configuration to automatically cancel GitHub Actions runs when a new commit is pushed that would replace them (to save a little electricity and other cloud resources and GHA minutes)