### PR TITLE
[docs] switch vignettes from 'rmarkdown' to 'markdown'

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -19,5 +19,5 @@ sudo apt-get install \
     tidy \
     qpdf
 
-Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'purrr', 'rmarkdown', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
+Rscript -e "install.packages(c('assertthat', 'covr', 'data.table', 'futile.logger', 'httr', 'jsonlite', 'knitr', 'lintr', 'markdown', 'purrr', 'stringr', 'testthat', 'uuid'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
 cp test-data/* r-pkg/inst/testdata/

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     uuid
 Suggests:
     knitr,
-    rmarkdown,
+    markdown,
     testthat
 License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/uptasticsearch

--- a/r-pkg/vignettes/FAQ.Rmd
+++ b/r-pkg/vignettes/FAQ.Rmd
@@ -2,13 +2,15 @@
 title: "Frequently Asked Questions"
 author: "Stephanie Kirmer"
 date: "`r Sys.Date()`"
-output: 
-  rmarkdown::html_vignette:
-      toc: TRUE
+output:
+  markdown::html_format:
+    options:
+      toc: true
       toc_depth: 2
+      number_sections: true
 vignette: >
   %\VignetteIndexEntry{FAQ - Help with Uptasticsearch Functionalities}
-  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEngine{knitr::knitr}
   %\VignetteEncoding{UTF-8}
 ---
 


### PR DESCRIPTION
Fixes #228 

See the background in https://github.com/microsoft/LightGBM/pull/6258 ... in general, `{markdown}` is much lighter-weight than `{rmarkdown}`. Perfect for `{uptasticsearch}`, which just has 1 very simple and small vignette that doesn't require any of the powerful features that `{rmarkdown}` comes with.