### PR TITLE
remove uses of testthat::with_mock() (fixes #223)

### DIFF
--- a/r-pkg/R/helperfuns.R
+++ b/r-pkg/R/helperfuns.R
@@ -1,0 +1,34 @@
+# [title] Extract the content of an HTTP response into a different format
+# [name] .content
+# [description] Mainly here to making mocking easier in testing.
+# [references] https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls
+#' @importFrom httr content
+.content <- function(response, as) {
+    return(httr::content(response, as = as))
+}
+
+# [title] Execute an HTTP request and return the result
+# [name] .request
+# [description] Mainly here to making mocking easier in testing, but this
+#               also centralizes the mechanism for HTTP request exexcution in one place.
+# [references] https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls
+#' @importFrom httr RETRY
+.request <- function(verb, url, config, body) {
+    result <- httr::RETRY(
+        verb = verb
+        , url = url
+        , config = config
+        , body = body
+    )
+    return(result)
+}
+
+# [title] Raise an exception if an HTTP response indicates an error
+# [name] .stop_for_status
+# [description] Mainly here to making mocking easier in testing.
+# [references] https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls
+#' @importFrom httr stop_for_status
+.stop_for_status <- function(response) {
+    httr::stop_for_status(response)
+    return(invisible(NULL))
+}

--- a/r-pkg/tests/testthat/test-get_fields.R
+++ b/r-pkg/tests/testthat/test-get_fields.R
@@ -28,13 +28,23 @@ test_that("get_fields works as expected when mocked", {
         alias = c("alias1", "alias2")
         , index = c("company", "otherIndex")
     )
-    # nolint start
     testthat::with_mocked_bindings(
-        `.content` = function(...) {return(jsonlite::fromJSON(txt = test_json))},
-        `.get_aliases` = function(...) {return(aliasDT)},
-        `.get_es_version` = function(...) {return("6")},
-        `.request` = function(...) {return(NULL)},
-        `.stop_for_status` = function(...) {return(NULL)},
+        `.content` = function(...) {
+            return(jsonlite::fromJSON(txt = test_json))
+        },
+        `.get_aliases` = function(...) {
+            return(aliasDT)
+        },
+        `.get_es_version` = function(...) {
+            return("6")
+        }
+        ,
+        `.request` = function(...) {
+            return(NULL)
+        },
+        `.stop_for_status` = function(...) {
+            return(NULL)
+        },
         {
             outDT <- get_fields(
                 es_host = "http://db.mycompany.com:9200"


### PR DESCRIPTION
Fixes #223

This removes the one use of `testthat::with_mock()` in the package, for the reasons mentioned in #223.

It does this by moving the `{httr}` calls we want to mock into separate internal functions within `{uptasticsearch}`. Those thin wrappers are introduced here mainly because of the advice from https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls

> _It's trickier to mock functions in other packages that you call with `::`. For example, take this minor variation:_
>
> ```r
> some_function <- function() {
>   anotherpackage::another_function()
> }
> ```
>
> _To mock this function, you'd need to modify `another_function()` inside the `anotherpackage` package. You can do this by supplying the `.package` argument to `local_mocked_bindings()` but we don't recommend it because it will affect all calls to `anotherpackage::another_function()`, not just the calls originating in your package. Instead, it's safer to either import the function into your package, or make a wrapper that you can mock._

## Notes for Reviewers

These new internal functions are used in multiple files, so I wanted to centralize them in one other file. Introducing: `helperfuns.R` 😊 