### PR TITLE
prefix all internal functions with '.'

### DIFF
--- a/r-pkg/R/assertions.R
+++ b/r-pkg/R/assertions.R
@@ -9,7 +9,7 @@
     if (isTRUE(res)) {
         return(invisible(TRUE))
     }
-    log_fatal(msg)
+    .log_fatal(msg)
 }
 
 # [title] check if an object is a count

--- a/r-pkg/R/chomp_aggs.R
+++ b/r-pkg/R/chomp_aggs.R
@@ -27,14 +27,14 @@ chomp_aggs <- function(aggs_json = NULL) {
     # If nothing was passed to aggs_json, return NULL and warn
     if (is.null(aggs_json)) {
         msg <- "You did not pass any input data to chomp_aggs. Returning NULL."
-        log_warn(msg)
+        .log_warn(msg)
         return(invisible(NULL))
     }
 
     if (!is.character(aggs_json)) {
         msg <- paste0("The first argument of chomp_aggs must be a character vector."
                       , "You may have passed an R list. Try querying with uptasticsearch:::.search_request()")
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     # Parse the input JSON to a list object
@@ -49,7 +49,7 @@ chomp_aggs <- function(aggs_json = NULL) {
 
     # Gross special-case handler for one-level extended_stats aggregation
     if (.IsExtendedStatsAgg(jsonList[["aggregations"]][[aggNames]])) {
-        log_info("es_search is assuming that this result is a one-level 'extended_stats' result.")
+        .log_info("es_search is assuming that this result is a one-level 'extended_stats' result.")
         jsonList[["aggregations"]][[1]][["std_deviation_bounds.upper"]] <- jsonList[["aggregations"]][[1]][["std_deviation_bounds"]][["upper"]]
         jsonList[["aggregations"]][[1]][["std_deviation_bounds.lower"]] <- jsonList[["aggregations"]][[1]][["std_deviation_bounds"]][["lower"]]
         jsonList[["aggregations"]][[1]][["std_deviation_bounds"]] <- NULL
@@ -57,7 +57,7 @@ chomp_aggs <- function(aggs_json = NULL) {
 
     # Gross special-case handler for one-level percentiles aggregation
     if (.IsPercentilesAgg(jsonList[["aggregations"]][[aggNames]])) {
-        log_info("es_search is assuming that this result is a one-level 'percentiles' result.")
+        .log_info("es_search is assuming that this result is a one-level 'percentiles' result.")
 
         # Replace names like `25.0` with something that will be easier for users to understand
         # Doing this changes column names like thing.values.25.0 to thing.percentile_25.0
@@ -67,7 +67,7 @@ chomp_aggs <- function(aggs_json = NULL) {
     }
 
     if (.IsSigTermsAgg(jsonList[["aggregations"]][[aggNames]])) {
-        log_info("es_search is assuming that this result is a one-level 'significant terms' result.")
+        .log_info("es_search is assuming that this result is a one-level 'significant terms' result.")
 
         # We can grab that nested data.frame and break out right now
         outDT <- data.table::as.data.table(jsonList[["aggregations"]][[aggNames]][["buckets"]])
@@ -77,7 +77,7 @@ chomp_aggs <- function(aggs_json = NULL) {
 
     # check for an empty result
     if (identical(jsonList[["aggregations"]][[aggNames]][["buckets"]], list())) {
-        log_info("this aggregation result was empty. Returning NULL")
+        .log_info("this aggregation result was empty. Returning NULL")
         return(invisible(NULL))
     }
 

--- a/r-pkg/R/chomp_hits.R
+++ b/r-pkg/R/chomp_hits.R
@@ -41,7 +41,7 @@ chomp_hits <- function(hits_json = NULL, keep_nested_data_cols = TRUE) {
     # If nothing was passed to hits_json, return NULL and warn
     if (is.null(hits_json)) {
         msg <- "You did not pass any input data to chomp_hits. Returning NULL."
-        log_warn(msg)
+        .log_warn(msg)
         return(invisible(NULL))
     }
 
@@ -50,7 +50,7 @@ chomp_hits <- function(hits_json = NULL, keep_nested_data_cols = TRUE) {
                       , "You may have passed an R list. In that case, if you already "
                       , "used jsonlite::fromJSON(), you can just call "
                       , "data.table::as.data.table().")
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     # Parse the input JSON to a list object
@@ -76,14 +76,14 @@ chomp_hits <- function(hits_json = NULL, keep_nested_data_cols = TRUE) {
                 , "Consider using unpack_nested_data for one:\n"
                 , toString(names(colTypes)[colTypes == "list"])
             )
-            log_info(msg)
+            .log_info(msg)
         } else {
 
             msg <- paste(
                 "Deleting the following nested data columns:\n"
                 , toString(names(colTypes)[colTypes == "list"])
             )
-            log_warn(msg)
+            .log_warn(msg)
             batchDT <- batchDT[, !names(colTypes[colTypes == "list"]), with = FALSE]
         }
     }

--- a/r-pkg/R/get_fields.R
+++ b/r-pkg/R/get_fields.R
@@ -21,7 +21,7 @@
         return(indices)
     }
 
-    log_warn(paste0(
+    .log_warn(paste0(
         "Excluding the following indices assumed to be internal 'system' indices: ["
         , toString(indices)
         , "]. To suppress this warning and/or to query these indices, pass a vector of index names "  # nolint[non_portable_path]
@@ -71,7 +71,7 @@ get_fields <- function(es_host
         msg <- paste("get_fields must be passed a valid es_indices."
                      , "You provided", toString(es_indices)
                      , "which resulted in an empty string")
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     major_version <- .get_es_version(
@@ -80,7 +80,7 @@ get_fields <- function(es_host
 
     # The use of "_all" to indicate "all indices" was removed in Elasticsearch 7.
     if (as.integer(major_version) > 6 && indices == "_all") {
-        log_warn(sprintf(
+        .log_warn(sprintf(
             paste0(
                 "You are running Elasticsearch version '%s.x'. _all is not supported in this version."
                 , " Pulling all indices with 'GET /_cat/indices' for you."  # nolint[non_portable_path]
@@ -107,7 +107,7 @@ get_fields <- function(es_host
     es_url <- sprintf("%s/%s/_mapping", es_url, indices)  # nolint[non_portable_path]
 
     ########################## make the query ################################
-    log_info(paste("Getting indexed fields for indices:", indices))
+    .log_info(paste("Getting indexed fields for indices:", indices))
 
     result <- .request(
         verb = "GET"
@@ -147,7 +147,7 @@ get_fields <- function(es_host
     rawAliasDT <- .get_aliases(es_host = es_host)
     if (!is.null(rawAliasDT)) {
 
-        log_info("Replacing index names with aliases")
+        .log_info("Replacing index names with aliases")
 
         # duplicate the mapping results for every alias. Idea is that you should be able to rely
         # on the results of get_fields to programmatically generate queries, and you should have a
@@ -179,7 +179,7 @@ get_fields <- function(es_host
     # log some information about this request to the user
     numFields <- nrow(mappingDT)
     numIndex <- mappingDT[, data.table::uniqueN(index)]
-    log_info(paste("Retrieved", numFields, "fields across", numIndex, "indices"))
+    .log_info(paste("Retrieved", numFields, "fields across", numIndex, "indices"))
 
     return(mappingDT)
 }

--- a/r-pkg/R/logging.R
+++ b/r-pkg/R/logging.R
@@ -1,17 +1,16 @@
-
 #' @importFrom futile.logger flog.info
-log_info <- function(...) {
+.log_info <- function(...) {
     futile.logger::flog.info(...)
 }
 
 #' @importFrom futile.logger flog.warn
-log_warn <- function(...) {
+.log_warn <- function(...) {
     futile.logger::flog.warn(...)
     warning(...)
 }
 
 #' @importFrom futile.logger flog.fatal
-log_fatal <- function(...) {
+.log_fatal <- function(...) {
     futile.logger::flog.fatal(...)
     stop(...)
 }

--- a/r-pkg/R/parse_date_time.R
+++ b/r-pkg/R/parse_date_time.R
@@ -44,7 +44,7 @@ parse_date_time <- function(input_df
                      , "You provided an object of class"
                      , toString(class(input_df))
                      , "to input_df.")
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     # Break if date_cols is not a character vector
@@ -52,7 +52,7 @@ parse_date_time <- function(input_df
         msg <- paste("The date_cols argument in parse_date_time expects",
                      "a character vector of column names. You gave an object",
                      "of class", toString(class(date_cols)))
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     # Break if any of the date_cols are not actually in this DT
@@ -61,7 +61,7 @@ parse_date_time <- function(input_df
         msg <- paste("The following columns, which you passed to date_cols,",
                      "do not actually exist in input_df:",
                      toString(not_there))
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     # Other input checks we don't have explicit error messages for

--- a/r-pkg/R/unpack_nested_data.R
+++ b/r-pkg/R/unpack_nested_data.R
@@ -42,15 +42,15 @@ unpack_nested_data <- function(chomped_df, col_to_unpack)  {
     # Input checks
     if (!data.table::is.data.table(chomped_df)) {
         msg <- "For unpack_nested_data, chomped_df must be a data.table"
-        log_fatal(msg)
+        .log_fatal(msg)
     }
     if (!.is_string(col_to_unpack)) {
         msg <- "For unpack_nested_data, col_to_unpack must be a character of length 1"
-        log_fatal(msg)
+        .log_fatal(msg)
     }
     if (!(col_to_unpack %in% names(chomped_df))) {
         msg <- "For unpack_nested_data, col_to_unpack must be one of the column names"
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     inDT <- data.table::copy(chomped_df)
@@ -71,7 +71,7 @@ unpack_nested_data <- function(chomped_df, col_to_unpack)  {
     # Check for empty column
     if (all(purrr::map_int(listDT, NROW) == 0)) {
         msg <- "The column given to unpack_nested_data had no data in it."
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     listDT[lengths(listDT) == 0] <- NA
@@ -101,7 +101,7 @@ unpack_nested_data <- function(chomped_df, col_to_unpack)  {
         newDT <- data.table::rbindlist(newDT, fill = TRUE, idcol = joinCol)
     } else {
         msg <- paste0("Each row in column ", col_to_unpack, " must be a data frame or a vector.")
-        log_fatal(msg)
+        .log_fatal(msg)
     }
 
     # Join it back in


### PR DESCRIPTION
Prefixes all the logging functions with `.`, to make it clearer that they're internal-only.

All other internal functions in the package are already prefixed with `.`.

## Notes for Reviewers

I expect this to be non-controversial, so just going to admin-merge it as soon as CI passes.