### PR TITLE
[ci] reduce duplication in scripts, clean up containers

### DIFF
--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -14,6 +14,8 @@ if (!identical(loggerOptions, list())) {
 }
 futile.logger::flog.threshold(0)
 
+ES_HOST <- "http://127.0.0.1:9200"
+
 #--- es_search
 
     # search request
@@ -21,7 +23,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         outDT <- es_search(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_index = "shakespeare"
             , max_hits = 100
             , size = 100
@@ -34,7 +36,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         outDT <- es_search(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_index = "shakespeare"
             , max_hits = 30
             , size = 2
@@ -47,7 +49,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         outDT <- es_search(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_index = "shakespeare"
             , max_hits = 30
             , size = 2
@@ -62,7 +64,7 @@ futile.logger::flog.threshold(0)
 
         expect_error({
             outDT <- es_search(
-                es_host = "http://127.0.0.1:9200"
+                es_host = ES_HOST
                 , es_index = "shakespeare"
                 , max_hits = 100
                 , size = 100
@@ -77,7 +79,7 @@ futile.logger::flog.threshold(0)
 
         expect_warning({
             outDT <- es_search(
-                es_host = "http://127.0.0.1:9200"
+                es_host = ES_HOST
                 , es_index = "shakespeare"
                 , max_hits = 9999
             )
@@ -91,7 +93,7 @@ futile.logger::flog.threshold(0)
 
         expect_warning({
             outDT <- es_search(
-                es_host = "http://127.0.0.1:9200"
+                es_host = ES_HOST
                 , es_index = "shakespeare"
                 , max_hits = 12
                 , size = 7
@@ -108,7 +110,7 @@ futile.logger::flog.threshold(0)
         #       and I want to avoid exposing our tests to changes in the query DSL
         expect_warning({
             outDT <- es_search(
-                es_host = "http://127.0.0.1:9200"
+                es_host = ES_HOST
                 , es_index = "empty_index"
             )
         }, regexp = "Query is syntactically valid but 0 documents were matched")
@@ -120,7 +122,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         outDT <- es_search(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_index = "shakespeare"
             , max_hits = 100
             , query = '{"aggs": {"thing": {"terms": {"field": "speaker", "size": 12}}}}'  # nolint[quotes]
@@ -150,7 +152,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         outDT <- es_search(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_index = "shakespeare"
             , max_hits = 100
             , query = '{"aggs": {"name_i_picked": {"terms": {"field": "speaker", "size": 12}}}}'  # nolint[quotes]
@@ -178,7 +180,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         outDT <- es_search(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_index = "shakespeare"
             , max_hits = 100
             , query = '{"aggs": {"blegh": {"terms": {"field": "nonsense_field"}}}}'  # nolint[quotes]
@@ -191,7 +193,7 @@ futile.logger::flog.threshold(0)
     test_that(".get_es_version works", {
         testthat::skip_on_cran()
 
-        ver <- uptasticsearch:::.get_es_version(es_host = "http://127.0.0.1:9200")
+        ver <- uptasticsearch:::.get_es_version(es_host = ES_HOST)
 
         # is a string
         expect_true(.is_string(ver), info = paste0("returned version: ", ver))
@@ -226,7 +228,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         result <- .get_aliases(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
         )
         expect_null(result)
     })
@@ -235,7 +237,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         fieldDT <- get_fields(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_indices = "_all"
         )
         expect_true(data.table::is.data.table(fieldDT))
@@ -276,7 +278,7 @@ futile.logger::flog.threshold(0)
 
         # get_fields should work
         fieldDT <- get_fields(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_indices = "_all"
         )
 
@@ -336,7 +338,7 @@ futile.logger::flog.threshold(0)
         #       Elasticsearch 7, but we use it here so that old uptasticsearch code
         #       continues to work
         fieldDT <- get_fields(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_indices = "_all"
         )
 
@@ -373,7 +375,7 @@ futile.logger::flog.threshold(0)
 
         # get_fields should work targeting a specific index with aliases
         fieldDT <- get_fields(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_indices = "shakespeare"
         )
 
@@ -423,7 +425,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         fieldDT <- get_fields(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_indices = "empty_index"
         )
         expect_true(data.table::is.data.table(fieldDT))
@@ -450,7 +452,7 @@ futile.logger::flog.threshold(0)
         testthat::skip_on_cran()
 
         fieldDT <- get_fields(
-            es_host = "http://127.0.0.1:9200"
+            es_host = ES_HOST
             , es_indices = c("empty_index", "shakespeare")
         )
         expect_true(data.table::is.data.table(fieldDT))

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -11,38 +11,39 @@ WDIR=$(pwd)
 TESTDIR=${WDIR}/sandbox
 SAMPLE_DATA_FILE=$(pwd)/test-data/sample.json
 ES_HOST="127.0.0.1"
+ES_PORT="9200"
 
 echo "Starting up Elasticsearch..."
 
 case "${ES_VERSION}" in
 
 1.0.3)
-    docker run -d -p 9200:9200 barnybug/elasticsearch:1.0.3
+    docker run --rm -d -p "${ES_PORT}:9200" barnybug/elasticsearch:1.0.3
     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
     ;;
 1.7.6)
-    docker run -d -p 9200:9200 elasticsearch:1.7.6
+    docker run --rm -d -p "${ES_PORT}:9200" elasticsearch:1.7.6
     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
     ;;
 2.4.6)
-    docker run -d -p 9200:9200 elasticsearch:2.4.6
+    docker run --rm -d -p "${ES_PORT}:9200" elasticsearch:2.4.6
     MAPPING_FILE=$(pwd)/test-data/legacy_shakespeare_mapping.json
     ;;
 5.6.16)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:5.6.16
     MAPPING_FILE=$(pwd)/test-data/es5_shakespeare_mapping.json
     ;;
 6.8.15)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:6.8.15
     MAPPING_FILE=$(pwd)/test-data/es6_shakespeare_mapping.json
     ;;
 7.0.1)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:7.0.1
@@ -50,7 +51,7 @@ case "${ES_VERSION}" in
     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;
 7.17.22)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:7.17.22
@@ -58,7 +59,7 @@ case "${ES_VERSION}" in
     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;
 8.0.1)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:8.0.1
@@ -66,7 +67,7 @@ case "${ES_VERSION}" in
     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;
 8.5.3)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:8.5.3
@@ -74,7 +75,7 @@ case "${ES_VERSION}" in
     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;
 8.10.4)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:8.10.4
@@ -82,7 +83,7 @@ case "${ES_VERSION}" in
     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;
 8.15.5)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:8.15.5
@@ -90,7 +91,7 @@ case "${ES_VERSION}" in
     SAMPLE_DATA_FILE=$(pwd)/test-data/sample_es7.json
     ;;
 8.17.2)
-    docker run -d -p 9200:9200 \
+    docker run --rm -d -p "${ES_PORT}:9200" \
         -e "discovery.type=single-node" \
         -e "xpack.security.enabled=false" \
         docker.elastic.co/elasticsearch/elasticsearch:8.17.2


### PR DESCRIPTION
Contributes to #90

This proposes some miscellaneous cleanup to testing and development scripts.

* reduces duplication in `test-integration.R`
* passes `--rm` to all `docker run` calls, to clean up containers when they exit

## Notes for reviewers

After a few weeks of active development here, I have a bunch of stranded containers.

```shell
docker container ls --all
```

<img width="1415" alt="image" src="https://github.com/user-attachments/assets/a83d6e56-8334-4722-a009-31f7aa8b3af1" />

These take up a little storage space, and are just noise when you're looking for other containers. Adding `--rm` to every `docekr run` ensures that they automatically get cleaned up when the containers exit.