### PR TITLE
[docs] fix links with redirects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you are reporting a bug, please describe as many as possible of the following
 The text of your issue should answer the question "what did you expect `uptasticsearch` to do and what did it actually do?".
 
 We welcome any and all bug reports.
-However, we'll be best able to help you if you can reduce the bug down to a **minimum working example**
+However, we'll be best able to help you if you can reduce the bug down to a **minimum working example**.
 A **minimal working example (MWE)** is the minimal code needed to reproduce the incorrect behavior you are reporting.
 Please consider the [stackoverflow guide on MWE authoring](https://stackoverflow.com/help/mcve).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to uptasticsearch
 
-The primary goal of this guide is to help you contribute to `uptasticsearch` as quickly and as easily possible. It's secondary goal is to document important information for maintainers.
+The primary goal of this guide is to help you contribute to `uptasticsearch` as quickly and as easily possible.
+Its secondary goal is to document important information for maintainers.
 
 #### Table of contents
 
@@ -26,13 +27,17 @@ If you are reporting a bug, please describe as many as possible of the following
 
 The text of your issue should answer the question "what did you expect `uptasticsearch` to do and what did it actually do?".
 
-We welcome any and all bug reports. However, we'll be best able to help you if you can reduce the bug down to a **minimum working example**. A **minimal working example (MWE)** is the minimal code needed to reproduce the incorrect behavior you are reporting. Please consider the [stackoverflow guide on MWE authoring](https://stackoverflow.com/help/mcve).
+We welcome any and all bug reports.
+However, we'll be best able to help you if you can reduce the bug down to a **minimum working example**
+A **minimal working example (MWE)** is the minimal code needed to reproduce the incorrect behavior you are reporting.
+Please consider the [stackoverflow guide on MWE authoring](https://stackoverflow.com/help/mcve).
 
 If you're interested in submitting a pull request to address the bug you're reporting, please indicate that in the issue.
 
 ### Feature Requests
 
-We welcome feature requests, and prefer the issues page as a place to log and categorize them. If you would like to request a new feature, please open an issue there and add the `enhancement` tag.
+We welcome feature requests, and prefer the issues page as a place to log and categorize them.
+If you would like to request a new feature, please open an issue there and add the `enhancement` tag.
 
 Good feature requests will note all of the following:
 
@@ -44,13 +49,15 @@ If you're interested in submitting a pull request to address the bug you're repo
 
 ## Submitting a Pull Request <a name="prs"></a>
 
-We welcome [pull requests](https://help.github.com/articles/about-pull-requests/) from anyone interested in contributing to `uptasticsearch`. This section describes best practices for submitting PRs to this project.
+We welcome [pull requests](https://help.github.com/articles/about-pull-requests/) from anyone interested in contributing to `uptasticsearch`.
+This section describes best practices for submitting PRs to this project.
 
 If you are interested in making changes that impact the way `uptasticsearch` works, please [open an issue](#issues) proposing what you would like to work on before you spend time creating a PR.
 
 If you would like to make changes that do not directly impact how `uptasticsearch` works, such as improving documentation, adding unit tests, or minor bug fixes, please feel free to implement those changes and directly create PRs.
 
-If you are not sure which of the preceding conditions applies to you, open an issue. We'd love to hear your idea!
+If you are not sure which of the preceding conditions applies to you, open an issue.
+We'd love to hear your idea!
 
 To submit a PR, please follow these steps:
 
@@ -77,7 +84,8 @@ Each build actually runs many sub-builds. Those sub-builds run once for each com
 
 As of this writing, this project has clients in one programming language: [R](./r-pkg).
 
-The set of Elasticsearch versions this project tests against changes regularly as [new Elasticsearch versions are released](https://www.elastic.co/downloads/past-releases#elasticsearch). The strategy in this project is to test against the following Elasticsearch versions:
+The set of Elasticsearch versions this project tests against changes regularly as [new Elasticsearch versions are released](https://www.elastic.co/downloads/past-releases#elasticsearch).
+The strategy in this project is to test against the following Elasticsearch versions:
 
 > `uptasticsearch` is tested against the most recent release in every major release stream from 1.x onwards
 
@@ -101,15 +109,19 @@ So, for example, as of January 2025 that meant we tested against:
 * 8.15.5
 * 8.17.2
 
-You may notice that this strategy means that `uptasticsearch` is tested for backwards compatibility with Elasticsearch versions which have already reached [End-of-Life](https://www.elastic.co/support/eol). For example, support for Elasticsearch 1.7.x officially ended in January 2017.
+You may notice that this strategy means that `uptasticsearch` is tested for backwards compatibility with Elasticsearch versions which have already reached [End-of-Life](https://www.elastic.co/support/eol).
+For example, support for Elasticsearch 1.7.x officially ended in January 2017.
 We test these old versions because we know of users whose companies still run those versions, and for whom Elasticsearch upgrades are prohibitively expensive.
 In general, upgrades across major versions pre-6.x [require a full cluster restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
 
 ### Running Tests Locally <a name="testing-local"></a>
 
-When developing on this package, you may want to run Elasticsearch locally to speed up the testing cycle. We've provided some gross bash scripts at the root of this repo to help!
+When developing on this package, you may want to run Elasticsearch locally to speed up the testing cycle.
+We've provided some gross bash scripts at the root of this repo to help!
 
-To run the code below, you will need [Docker](https://www.docker.com/). Note that I've passed an argument to `setup_local.sh` indicating the version of Elasticsearch I want to run. Look at the source code of `setup_local.sh` for a list of the valid arguments.
+To run the code below, you will need [Docker](https://www.docker.com/).
+Note that I've passed an argument to `setup_local.sh` indicating the version of Elasticsearch I want to run.
+Look at the source code of `setup_local.sh` for a list of the valid arguments.
 
 ```shell
 # Start up Elasticsearch on localhost:9200 and seed it with data
@@ -127,7 +139,8 @@ make coverage
 
 ### Checking code style
 
-The R package's code style is tested with `{lintr}`. To check the code locally, run the following
+The R package's code style is tested with `{lintr}`.
+To check the code locally, run the following
 
 ```shell
 Rscript .ci/lint-r-code.R $(pwd)
@@ -135,7 +148,8 @@ Rscript .ci/lint-r-code.R $(pwd)
 
 ## Releases <a name="releases"></a>
 
-This section is intended for maintainers. It describes how to prepare an `uptasticsearch` release.
+This section is intended for maintainers.
+It describes how to prepare an `uptasticsearch` release.
 
 ### CRAN
 
@@ -149,9 +163,11 @@ This is a manual process, with the following steps.
 
 Open a PR with a branch name `release/v0.0.0` (replacing 0.0.0 with the actual version number).
 
-Add a section for this release to `NEWS.md`.  This file details the new features, changes, and bug fixes that occurred since the last version.
+Add a section for this release to `NEWS.md`.
+This file details the new features, changes, and bug fixes that occurred since the last version.
 
-Add a section for this release to `cran-comments.md`. This file holds details of our submission comments to CRAN and their responses to our submissions.
+Add a section for this release to `cran-comments.md`.
+This file holds details of our submission comments to CRAN and their responses to our submissions.
 
 Change the `Version:` field in `DESCRIPTION` to the official version you want on CRAN (should not have a trailing `.9000`).
 
@@ -167,23 +183,31 @@ Build the package tarball by running the following
 make build
 ```
 
-Go to https://cran.r-project.org/submit.html and submit this new release! In the upload section, upload the tarball you just built.
+Go to https://cran.r-project.org/submit.html and submit this new release!
+In the upload section, upload the tarball you just built.
 
 **Handle feedback from CRAN**
 
 The maintainer will get an email from CRAN with the status of the submission.
 
-If the submission is not accepted, do whatever CRAN asked you to do. Update `cran-comments.md` with some comments explaining the requested changes. Rebuild the `pkgdown` site. Repeat this process until the package gets accepted.
+If the submission is not accepted, do whatever CRAN asked you to do.
+Update `cran-comments.md` with some comments explaining the requested changes.
+Repeat this process until the package gets accepted.
 
 **Merge the Pull Request**
 
-Once the submission is accepted, great! Update `cran-comments.md` and merge the PR.
+Once the submission is accepted, great!
+Update `cran-comments.md` and merge the PR.
 
 **Create a Release on GitHub**
 
-We use [the releases section](https://github.com/uptake/uptasticsearch/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes::install_github()` for old versions.
+We use [the releases section](https://github.com/uptake/uptasticsearch/releases) in the repo to categorize certain important commits as release checkpoints.
+This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes::install_github()` for old versions.
 
-Navigate to https://github.com/uptake/uptasticsearch/releases/new. Click the dropdown in the "target" section, then click "recent commits". Choose the latest commit for the release PR you just merged. This will automatically create a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on that commit and tell Github which revision to build when people ask for a given release.
+Navigate to https://github.com/uptake/uptasticsearch/releases/new.
+Click the dropdown in the "target" section, then click "recent commits".
+Choose the latest commit for the release PR you just merged.
+This will automatically create a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on that commit and tell Github which revision to build when people ask for a given release.
 
 Add some notes explaining what has changed since the previous release.
 
@@ -191,9 +215,11 @@ Add some notes explaining what has changed since the previous release.
 
 The R project is also released to `conda-forge`, under the name `r-uptasticsearch`.
 
-`conda-forge` releases can only be done after releasing to CRAN. The details of `r-uptasticsearch` are managed in https://github.com/conda-forge/r-uptasticsearch-feedstock.
+`conda-forge` releases can only be done after releasing to CRAN.
+The details of `r-uptasticsearch` are managed in https://github.com/conda-forge/r-uptasticsearch-feedstock.
 
-When a new version of the package is released to CRAN, `conda-forge`'s infrastructure will automatically create a pull request and update the recipe there. Merging that pull request will publish the new version to `conda-forge`.
+When a new version of the package is released to CRAN, `conda-forge`'s infrastructure will automatically create a pull request and update the recipe there.
+Merging that pull request will publish the new version to `conda-forge`.
 
 In case you need to make bigger changes to the recipe, see the `conda-forge` documentation:
 
@@ -204,4 +230,6 @@ In case you need to make bigger changes to the recipe, see the `conda-forge` doc
 
 Now that everything is done, the last thing you have to do is move the repo ahead of the version you just pushed to CRAN.
 
-Make a PR that adds a `.9999` on the end of the version you just released. This is a common practice in open source software development. It makes it obvious that the code in source control is newer than what's available from package managers, but doesn't interfere with the [semantic versioning](https://semver.org/) components of the package version.
+Make a PR that adds a `.9999` on the end of the version you just released.
+This is a common practice in open source software development.
+It makes it obvious that the code in source control is newer than what's available from package managers, but doesn't interfere with the [semantic versioning](https://semver.org/) components of the package version.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # uptasticsearch
 
 [![GitHub Actions Build Status](https://github.com/uptake/uptasticsearch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/uptake/uptasticsearch/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/uptake/uptasticsearch/branch/main/graph/badge.svg)](https://codecov.io/gh/uptake/uptasticsearch)
+[![codecov](https://codecov.io/gh/uptake/uptasticsearch/branch/main/graph/badge.svg)](https://app.codecov.io/gh/uptake/uptasticsearch)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version-last-release/uptasticsearch)](https://cran.r-project.org/package=uptasticsearch)
 [![CRAN\_Download\_Badge](https://cranlogs.r-pkg.org/badges/grand-total/uptasticsearch)](https://cran.r-project.org/package=uptasticsearch)
 
 ## Introduction
 
-`uptasticsearch` tackles the issue of getting data out of Elasticsearch and into a tabular format in R. It should work for all versions of Elasticsearch from 1.0.0 onwards, but [is not regularly tested against all of them](https://github.com/uptake/uptasticsearch/blob/main/CONTRIBUTING.md#gha). If you run into a problem, please [open an issue](https://github.com/uptake/uptasticsearch/issues).
+`uptasticsearch` tackles the issue of getting data out of Elasticsearch and into a tabular format in R.
+It should work for all versions of Elasticsearch from 1.0.0 onwards, but [is not regularly tested against all of them](https://github.com/uptake/uptasticsearch/blob/main/CONTRIBUTING.md#gha).
+If you run into a problem, please [open an issue](https://github.com/uptake/uptasticsearch/issues).
 
 # Table of contents
 
@@ -20,7 +22,8 @@
 
 ## How it Works <a name="howitworks"></a>
 
-The core functionality of this package is the `es_search()` function. This returns a `data.table` containing the parsed result of any given query. Note that this includes `aggs` queries.
+The core functionality of this package is the `es_search()` function.
+This returns a `data.table` containing the parsed result of any given query. Note that this includes `aggs` queries.
 
 ## Installation <a name="installation"></a>
 
@@ -106,7 +109,8 @@ commentDT <- es_search(
 
 ### Example 2: Aggregation Results <a name="example2"></a>
 
-Elasticsearch ships with a rich set of aggregations for creating summarized views of your data. `uptasticsearch` has built-in support for these aggregations.
+Elasticsearch ships with a rich set of aggregations for creating summarized views of your data.
+`uptasticsearch` has built-in support for these aggregations.
 
 In the example below, we use `uptasticsearch` to create daily timeseries of summary statistics like total revenue and average payment amount.
 
@@ -163,35 +167,44 @@ In the example above, we used the [date_histogram](https://www.elastic.co/guide/
 Please see the table below for the current status of the package.
 Note that names of the form "agg1 - agg2" refer to the ability to handled aggregations nested inside other aggregations.
 
-|Agg type                                     | R support?  |
-|:--------------------------------------------|:-----------:|
-|["cardinality"](http://bit.ly/2sn5Qiw)       |YES          |
-|["date_histogram"](http://bit.ly/2qIR97Z)    |YES          |
-|date_histogram - cardinality                 |YES          |
-|date_histogram - extended_stats              |YES          |
-|date_histogram - histogram                   |YES          |
-|date_histogram - percentiles                 |YES          |
-|date_histogram - significant_terms           |YES          |
-|date_histogram - stats                       |YES          |
-|date_histogram - terms                       |YES          |
-|["extended_stats"](http://bit.ly/2qKqsDU)    |YES          |
-|["histogram"](http://bit.ly/2sn4LXF)         |YES          |
-|["percentiles"](http://bit.ly/2sy4z7f)       |YES          |
-|["significant terms"](http://bit.ly/1KnhT1r) |YES          |
-|["stats"](http://bit.ly/2sn1t74)             |YES          |
-|["terms"](http://bit.ly/2mJyQ0C)             |YES          |
-|terms - cardinality                          |YES          |
-|terms - date_histogram                       |YES          |
-|terms - date_histogram - cardinality         |YES          |
-|terms - date_histogram - extended_stats      |YES          |
-|terms - date_histogram - histogram           |YES          |
-|terms - date_histogram - percentiles         |YES          |
-|terms - date_histogram - significant_terms   |YES          |
-|terms - date_histogram - stats               |YES          |
-|terms - date_histogram - terms               |YES          |
-|terms - extended_stats                       |YES          |
-|terms - histogram                            |YES          |
-|terms - percentiles                          |YES          |
-|terms - significant_terms                    |YES          |
-|terms - stats                                |YES          |
-|terms - terms                                |YES          |
+|Agg type                                   | support? |
+|:------------------------------------------|:--------:|
+|["cardinality"][1]                         |YES       |
+|["date_histogram"][2]                      |YES       |
+|date_histogram - cardinality               |YES       |
+|date_histogram - extended_stats            |YES       |
+|date_histogram - histogram                 |YES       |
+|date_histogram - percentiles               |YES       |
+|date_histogram - significant_terms         |YES       |
+|date_histogram - stats                     |YES       |
+|date_histogram - terms                     |YES       |
+|["extended_stats"][3]                      |YES       |
+|["histogram"][4]                           |YES       |
+|["percentiles"][5]                         |YES       |
+|["significant terms"][6]                   |YES       |
+|["stats"][7]                               |YES       |
+|["terms"][8]                               |YES       |
+|terms - cardinality                        |YES       |
+|terms - date_histogram                     |YES       |
+|terms - date_histogram - cardinality       |YES       |
+|terms - date_histogram - extended_stats    |YES       |
+|terms - date_histogram - histogram         |YES       |
+|terms - date_histogram - percentiles       |YES       |
+|terms - date_histogram - significant_terms |YES       |
+|terms - date_histogram - stats             |YES       |
+|terms - date_histogram - terms             |YES       |
+|terms - extended_stats                     |YES       |
+|terms - histogram                          |YES       |
+|terms - percentiles                        |YES       |
+|terms - significant_terms                  |YES       |
+|terms - stats                              |YES       |
+|terms - terms                              |YES       |
+
+[1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
+[2]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
+[3]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html
+[4]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
+[5]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
+[6]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
+[7]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
+[8]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -238,7 +238,7 @@ es_search <- function(es_host
                       "\n\nIf you understand the costs and would like to make requests ",
                       "with a longer-lived context, re-run this function with ",
                       "ignore_scroll_restriction = TRUE.\n",
-                      "\nPlease see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll ",
+                      "\nPlease see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll ",  # nolint[line_length]
                       "for more information.")
         .log_fatal(msg)
     }

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -8,7 +8,7 @@
 #'                 as it has pulled this many hits. Default is \code{Inf}, meaning that
 #'                 all possible hits will be pulled.
 #' @param size Number of records per page of results.
-#'             See \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html}{Elasticsearch docs} for more.
+#'             See \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-from-size}{Elasticsearch docs} for more.
 #'             Note that this will be reset to 0 if you submit a \code{query_body} with
 #'             an "aggs" request in it. Also see \code{max_hits}.
 #' @param query_body String with a valid Elasticsearch query. Default is an empty query.
@@ -17,7 +17,7 @@
 #'               The scroll context will be refreshed every time you ask Elasticsearch
 #'               for another record, so this parameter should just be the amount of
 #'               time you expect to pass between requests. See the
-#'               \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html}{Elasticsearch scroll/pagination docs}
+#'               \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll}{Elasticsearch scroll/pagination docs}
 #'               for more information.
 #' @param n_cores Number of cores to distribute fetching and processing over.
 #' @param break_on_duplicates Boolean, defaults to TRUE. \code{es_search} uses the size of the
@@ -72,7 +72,7 @@
 #'                       , es_index = 'ticket_sales'
 #'                       , query_body = query_body)
 #' }
-#' @references \href{https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html}{Elasticsearch 6 scrolling strategy}
+#' @references \href{https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-scroll.html}{Elasticsearch 6 scrolling strategy}
 # nolint end
 es_search <- function(es_host
                       , es_index
@@ -162,7 +162,7 @@ es_search <- function(es_host
 # [param] es_host A string identifying an Elasticsearch host. This should be of the form
 #        [transfer_protocol][hostname]:[port]. For example, 'http://myindex.thing.com:9200'.
 # [param] es_index The name of an Elasticsearch index to be queried.
-# [param] size Number of records per page of results. See \href{https://www.elastic.co/guide/en/Elasticsearch/reference/current/search-request-from-size.html}{Elasticsearch docs} for more
+# [param] size Number of records per page of results. See \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-from-size}{Elasticsearch docs} for more
 # [param] query_body String with a valid Elasticsearch query to be passed to \code{\link[elastic]{Search}}.
 #                  Default is an empty query.
 # [param] scroll How long should the scroll context be held open? This should be a
@@ -205,7 +205,7 @@ es_search <- function(es_host
 # See the links below for more information on how scrolling in Elasticsearch works
 # and why certain design decisions were made in this function.
 # \itemize{
-# \item \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html}{Elasticsearch documentation on scrolling search}
+# \item \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll}{Elasticsearch documentation on scrolling search}
 # \item \href{https://github.com/elastic/elasticsearch/issues/14954}{GitHub issue thread explaining why this function does not parallelize requests}
 # \item \href{https://github.com/elastic/elasticsearch/issues/11419}{GitHub issue thread explaining common symptoms that the scroll_id has changed and you are not using the correct Id}
 # \item \href{http://stackoverflow.com/questions/25453872/why-does-this-elasticsearch-scan-and-scroll-keep-returning-the-same-scroll-id}{More background on how/why Elasticsearch generates and changes the scroll_id}
@@ -238,7 +238,7 @@ es_search <- function(es_host
                       "\n\nIf you understand the costs and would like to make requests ",
                       "with a longer-lived context, re-run this function with ",
                       "ignore_scroll_restriction = TRUE.\n",
-                      "\nPlease see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html ",
+                      "\nPlease see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll ",
                       "for more information.")
         .log_fatal(msg)
     }
@@ -530,7 +530,7 @@ es_search <- function(es_host
 # [title] Make a scroll request with the strategy supported by Elasticsearch 5.x and later
 # [name] .new_scroll_request
 # [description] Make a scrolling request and return the result
-# [references] https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html
+# [references] https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-scroll.html
 .new_scroll_request <- function(es_host, scroll, scroll_id) {
 
     # Set up scroll_url

--- a/r-pkg/man/es_search.Rd
+++ b/r-pkg/man/es_search.Rd
@@ -29,7 +29,7 @@ uptasticsearch forbids this. If you want to execute a query over
 all indexes in the cluster, set this argument to \code{"_all"}.}
 
 \item{size}{Number of records per page of results.
-See \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html}{Elasticsearch docs} for more.
+See \href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-from-size}{Elasticsearch docs} for more.
 Note that this will be reset to 0 if you submit a \code{query_body} with
 an "aggs" request in it. Also see \code{max_hits}.}
 
@@ -40,7 +40,7 @@ duration string like "1m" (for one minute) or "15s" (for 15 seconds).
 The scroll context will be refreshed every time you ask Elasticsearch
 for another record, so this parameter should just be the amount of
 time you expect to pass between requests. See the
-\href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html}{Elasticsearch scroll/pagination docs}
+\href{https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll}{Elasticsearch scroll/pagination docs}
 for more information.}
 
 \item{max_hits}{Integer. If specified, \code{es_search} will stop pulling data as soon
@@ -108,5 +108,5 @@ resultDT <- es_search(es_host = "http://es.custdb.mycompany.com:9200"
 }
 }
 \references{
-\href{https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html}{Elasticsearch 6 scrolling strategy}
+\href{https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-scroll.html}{Elasticsearch 6 scrolling strategy}
 }


### PR DESCRIPTION
Fixes some NOTEs from `R CMD check` about URLs that now redirect.

<details><summary>full logs (click me)</summary>

```text
Found the following (possibly) invalid URLs:
  URL: http://bit.ly/1KnhT1r (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2mJyQ0C (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2qIR97Z (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2qKqsDU (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2sn1t74 (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2sn4LXF (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2sn5Qiw (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: http://bit.ly/2sy4z7f (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html)
    From: README.md
    Status: 200
    Message: OK
  URL: https://codecov.io/gh/uptake/uptasticsearch (moved to https://app.codecov.io/gh/uptake/uptasticsearch)
    From: README.md
    Status: 200
    Message: OK
  URL: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/search-request-scroll.html (moved to https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-scroll.html)
    From: man/es_search.Rd
    Status: 200
    Message: OK
  URL: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-from-size)
    From: man/es_search.Rd
    Status: 200
    Message: OK
  URL: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html (moved to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-scroll)
    From: man/es_search.Rd
    Status: 200
    Message: OK
```

</details>

Also does some minor refactoring of the docs while I'll touching them:

* ensures markdown files have only one sentence per line (to make diffs easier to read, and the `git blame` a little more useful)
* moves all those links in the aggregation table in the README down to references at the bottom of the page (I don't know the term for these), so link length doesn't affect the table formatting