### PR TITLE
[docs] remove defunct emails from DESCRIPTION

### DIFF
--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -4,11 +4,11 @@ Title: Get Data Frame Representations of 'Elasticsearch' Results
 Version: 0.4.0.9999
 Authors@R: c(
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut", "cre")),
-    person("Nick", "Paras", email = "nick.paras@uptake.com", role = c("aut")),
-    person("Austin", "Dickey", email = "austin.dickey@uptake.com", role = c("aut")),
+    person("Nick", "Paras", role = c("aut")),
+    person("Austin", "Dickey", role = c("aut")),
     person("Michael", "Frasco", email = "mfrasco6@gmail.com", role = c("ctb")),
-    person("Weiwen", "Gu", email = "weiwen.gu@uptake.com", role = c("ctb")),
-    person("Will", "Dearden", email = "william.dearden@uptake.com", role = c("ctb")),
+    person("Weiwen", "Gu", role = c("ctb")),
+    person("Will", "Dearden", role = c("ctb")),
     person("Uptake Technologies Inc.", role = c("cph")))
 Maintainer: James Lamb <jaylamb20@gmail.com>
 Description:


### PR DESCRIPTION
A few authors still have `@uptake.com` emails in `DESCRIPTION`. None of those people work there any more, so those emails can't be used to reach those people.

This proposes just removing the email addresses and not replacing them. CRAN only requires an email address for the maintainer.