### PR TITLE
update development version to 1.0.0.9999

### DIFF
--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: uptasticsearch
 Type: Package
 Title: Get Data Frame Representations of 'Elasticsearch' Results
-Version: 1.0.0
+Version: 1.0.0.9999
 Authors@R: c(
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut", "cre")),
     person("Nick", "Paras", role = c("aut")),


### PR DESCRIPTION
Follow-up to #253

Now that `v1.0.0` has been released, updates the development version to `v1.0.0.9999`.